### PR TITLE
fix: 비로그인 시 user_id 하드코딩 제거 및 로그인 체크 추가 (closes #1)

### DIFF
--- a/food-ai-platform-web/js/modal.js
+++ b/food-ai-platform-web/js/modal.js
@@ -58,6 +58,13 @@ function doLogin() {
 // ── 식품 추가/수정 모달 ──────────────────────────────────────
 
 function openAddItem() {
+  // 로그인 체크
+  if (!currentUser) {
+    showToast("⚠️ 로그인 후 식품을 추가할 수 있어요");
+    openLogin();
+    return;
+  }
+
   editingItemId = null;
 
   // 폼 초기화
@@ -72,6 +79,13 @@ function openAddItem() {
 }
 
 function openEditItem(item_id) {
+  // 로그인 체크
+  if (!currentUser) {
+    showToast("⚠️ 로그인 후 식품을 수정할 수 있어요");
+    openLogin();
+    return;
+  }
+
   const item = fridgeItems.find(i => i.item_id === item_id);
   if (!item) return;
 
@@ -89,6 +103,12 @@ function openEditItem(item_id) {
 }
 
 function submitItem() {
+  // 로그인 체크 (모달이 열린 상태에서 혹시 로그아웃된 경우 대비)
+  if (!currentUser) {
+    showToast("⚠️ 로그인이 필요합니다");
+    return;
+  }
+
   const name             = document.getElementById("f-name").value.trim();
   const quantity         = document.getElementById("f-qty").value.trim();
   const storage_location = document.getElementById("f-loc").value;
@@ -115,7 +135,7 @@ function submitItem() {
     // FRIDGE_ITEM 엔티티 구조 그대로 생성
     const newItem = {
       item_id          : nextItemId++,
-      user_id          : currentUser ? currentUser.user_id : 1,
+      user_id          : currentUser.user_id,   // 로그인된 사용자 ID만 사용
       name,
       quantity,
       storage_location,
@@ -133,6 +153,12 @@ function submitItem() {
 }
 
 function deleteItem(item_id) {
+  // 로그인 체크
+  if (!currentUser) {
+    showToast("⚠️ 로그인이 필요합니다");
+    return;
+  }
+
   if (!confirm("삭제하시겠습니까?")) return;
 
   // 실제 서비스: DELETE /api/fridge-items/:item_id

--- a/food-ai-platform-web/js/render.js
+++ b/food-ai-platform-web/js/render.js
@@ -251,13 +251,20 @@ function toggleSteps(btn) {
 
 /** 레시피 선택 → USER_RECIPE에 저장 */
 function selectRecipe(btn) {
+  // 로그인 체크
+  if (!currentUser) {
+    showToast("⚠️ 로그인 후 레시피를 선택할 수 있어요");
+    openLogin();
+    return;
+  }
+
   const recipe_name = btn.dataset.name;
   const category    = btn.dataset.category;
 
   // USER_RECIPE 엔티티에 추가 (실제 서비스: POST /api/user-recipes)
   userRecipes.push({
     recipe_id   : nextRecipeId++,
-    user_id     : currentUser ? currentUser.user_id : 1,
+    user_id     : currentUser.user_id,   // 로그인된 사용자 ID만 사용
     recipe_name,
     category,
   });


### PR DESCRIPTION
## 관련 이슈
closes #1

## 문제
비로그인 상태에서도 user_id가 하드코딩된 값으로 API 요청이 전송되어
인증되지 않은 사용자가 서비스를 이용할 수 있는 문제가 있었습니다.

## 해결 방법
- `modal.js` : API 요청 시 하드코딩된 user_id 제거, 로그인 여부 확인 후 미로그인 시 요청 차단
- `render.js` : 동일하게 로그인 체크 로직 추가 및 비로그인 사용자 접근 방지 처리

## 변경 파일
- `food-ai-platform-web/js/modal.js`
- `food-ai-platform-web/js/render.js`

## 테스트
- [x] 비로그인 상태에서 접근 시 로그인 요청 또는 차단 확인
- [x] 로그인 상태에서 정상 동작 확인