### PR TITLE
MySQL 기반 Docker 배포 환경 구성

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,160 @@
+name: Server CI/CD with Docker
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - food-ai-flatform-server/**
+      - .github/workflows/deploy.yml
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-server
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: food-ai-flatform-server
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Test
+        run: ./gradlew test
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./food-ai-flatform-server
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/food-ai-flatform-server:main
+          platforms: linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to OCI
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.OCI_HOST }}
+          username: ${{ secrets.OCI_USERNAME }}
+          key: ${{ secrets.OCI_KEY }}
+          port: 22
+          script: |
+            set -e
+
+            APP_IMAGE=${{ secrets.DOCKER_USERNAME }}/food-ai-flatform-server:main
+            APP_DIR="${{ secrets.APP_DIR }}"
+            APP_DIR=${APP_DIR:-/home/${{ secrets.OCI_USERNAME }}/food-ai-platform}
+            ENV_FILE="$APP_DIR/.env"
+            NETWORK_NAME=food-ai-platform
+            DB_CONTAINER=food-ai-platform-mysql
+            CONTAINER_NAME=food-ai-flatform-server
+            DB_IMAGE=mysql:8.4
+            APP_PORT=8080
+
+            mkdir -p "$APP_DIR"
+
+            if [ ! -f "$ENV_FILE" ]; then
+              echo ".env file not found: $ENV_FILE"
+              echo "Create it on the server before deploying."
+              exit 1
+            fi
+
+            read_env() {
+              grep -E "^$1=" "$ENV_FILE" | tail -n 1 | cut -d '=' -f 2- | tr -d '\r' || true
+            }
+
+            SERVER_PORT=$(read_env SERVER_PORT)
+            MYSQL_DATABASE=$(read_env MYSQL_DATABASE)
+            MYSQL_USER=$(read_env MYSQL_USER)
+            MYSQL_PASSWORD=$(read_env MYSQL_PASSWORD)
+            MYSQL_ROOT_PASSWORD=$(read_env MYSQL_ROOT_PASSWORD)
+            APP_PORT=${SERVER_PORT:-8080}
+            MYSQL_DATABASE=${MYSQL_DATABASE:-food_ai_platform}
+            MYSQL_USER=${MYSQL_USER:-food_ai_platform}
+
+            if [ -z "$MYSQL_PASSWORD" ]; then
+              echo "MYSQL_PASSWORD is required in $ENV_FILE"
+              exit 1
+            fi
+
+            if [ -z "$MYSQL_ROOT_PASSWORD" ]; then
+              echo "MYSQL_ROOT_PASSWORD is required in $ENV_FILE"
+              exit 1
+            fi
+
+            echo "${{ secrets.DOCKER_PASSWORD }}" | sudo docker login \
+              --username "${{ secrets.DOCKER_USERNAME }}" \
+              --password-stdin
+
+            sudo docker network create "$NETWORK_NAME" || true
+            sudo docker volume create food-ai-platform-mysql-data || true
+            sudo docker pull "$DB_IMAGE"
+            sudo docker pull "$APP_IMAGE"
+
+            if ! sudo docker ps -a --format '{{.Names}}' | grep -qx "$DB_CONTAINER"; then
+              sudo docker run -d \
+                --name "$DB_CONTAINER" \
+                --network "$NETWORK_NAME" \
+                --env-file "$ENV_FILE" \
+                -e MYSQL_DATABASE="$MYSQL_DATABASE" \
+                -e MYSQL_USER="$MYSQL_USER" \
+                -e MYSQL_PASSWORD="$MYSQL_PASSWORD" \
+                -e MYSQL_ROOT_PASSWORD="$MYSQL_ROOT_PASSWORD" \
+                -e TZ=Asia/Seoul \
+                -v food-ai-platform-mysql-data:/var/lib/mysql \
+                --restart unless-stopped \
+                "$DB_IMAGE" \
+                --character-set-server=utf8mb4 \
+                --collation-server=utf8mb4_unicode_ci
+            else
+              sudo docker start "$DB_CONTAINER"
+            fi
+
+            until sudo docker exec "$DB_CONTAINER" mysqladmin ping -h 127.0.0.1 -uroot -p"$MYSQL_ROOT_PASSWORD" --silent; do
+              echo "Waiting for MySQL to be ready..."
+              sleep 5
+            done
+
+            sudo docker stop "$CONTAINER_NAME" || true
+            sudo docker rm "$CONTAINER_NAME" || true
+
+            sudo docker run -d \
+              --name "$CONTAINER_NAME" \
+              --network "$NETWORK_NAME" \
+              -p "$APP_PORT:8080" \
+              --env-file "$ENV_FILE" \
+              -e SPRING_DATASOURCE_URL="jdbc:mysql://$DB_CONTAINER:3306/$MYSQL_DATABASE?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8" \
+              -e SPRING_DATASOURCE_USERNAME="$MYSQL_USER" \
+              -e SPRING_DATASOURCE_PASSWORD="$MYSQL_PASSWORD" \
+              -e TZ=Asia/Seoul \
+              --restart unless-stopped \
+              "$APP_IMAGE"
+
+            sudo docker image prune -f

--- a/food-ai-flatform-server/Dockerfile
+++ b/food-ai-flatform-server/Dockerfile
@@ -1,0 +1,20 @@
+FROM gradle:8.14.3-jdk21 AS builder
+
+WORKDIR /app
+
+COPY build.gradle settings.gradle gradlew ./
+COPY gradle ./gradle
+RUN chmod +x gradlew
+
+COPY src ./src
+RUN ./gradlew bootJar --no-daemon
+
+FROM eclipse-temurin:21-jre
+
+WORKDIR /app
+
+COPY --from=builder /app/build/libs/*.jar app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/food-ai-flatform-server/build.gradle
+++ b/food-ai-flatform-server/build.gradle
@@ -19,7 +19,9 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+    runtimeOnly 'com.mysql:mysql-connector-j'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'

--- a/food-ai-flatform-server/src/main/resources/application.properties
+++ b/food-ai-flatform-server/src/main/resources/application.properties
@@ -1,1 +1,9 @@
 spring.application.name=food-ai-flatform-server
+spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:mysql://localhost:3306/food_ai_platform?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8}
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME:food_ai_platform}
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:food_ai_platform}
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.open-in-view=false
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect


### PR DESCRIPTION
## 배경
현재 서버는 로컬 실행 기준의 최소 설정만 존재하고, 운영 서버에 자동 배포할 수 있는 Docker/CI-CD 구성이 없다.
또한 데이터베이스 연동이 준비되어 있지 않아 MySQL 컨테이너와 함께 실행할 수 있는 환경 구성이 필요하다.

## 목표
- 서버 애플리케이션을 Docker 이미지로 빌드할 수 있도록 구성한다.
- GitHub Actions를 통해 서버 변경 시 자동 배포되도록 구성한다.
- OCI 서버에서 MySQL 컨테이너와 서버 컨테이너를 함께 실행할 수 있도록 한다.
- Spring 서버가 환경변수 기반으로 MySQL datasource를 사용하도록 설정한다.

## 작업 내용
- `food-ai-flatform-server`용 `Dockerfile` 추가
- GitHub Actions 배포 워크플로우 추가
- Docker Hub 이미지 빌드 및 푸시 설정
- OCI 서버 SSH 배포 스크립트 추가
- MySQL 컨테이너 실행, 네트워크, 볼륨 구성
- Spring Boot에 MySQL 드라이버 및 JPA 의존성 추가
- `application.properties`에 datasource 설정 추가

## 완료 조건
- `main` 브랜치에 서버 변경 사항 푸시 시 GitHub Actions가 실행된다.
- Docker 이미지가 Docker Hub에 정상 푸시된다.
- OCI 서버에서 MySQL 컨테이너와 서버 컨테이너가 정상 기동된다.
- 서버가 MySQL datasource로 기동된다.
- `./gradlew test`가 통과한다.
