### PR TITLE
[BE] 백엔드 기본 구조 및 공통 응답/예외 처리 세팅

### DIFF
--- a/food-ai-flatform-server/build.gradle
+++ b/food-ai-flatform-server/build.gradle
@@ -19,12 +19,14 @@ repositories {
 }
 
 dependencies {
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'
     runtimeOnly 'com.mysql:mysql-connector-j'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testCompileOnly 'org.projectlombok:lombok'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testAnnotationProcessor 'org.projectlombok:lombok'

--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/auth/package-info.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/auth/package-info.java
@@ -1,0 +1,1 @@
+package com.example.foodaiflatformserver.auth;

--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/common/ApiErrorCode.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/common/ApiErrorCode.java
@@ -1,0 +1,35 @@
+package com.example.foodaiflatformserver.common;
+
+import org.springframework.http.HttpStatus;
+
+public enum ApiErrorCode {
+
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "INVALID_REQUEST", "요청 값이 올바르지 않습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "인증이 필요합니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "FORBIDDEN", "접근 권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "NOT_FOUND", "요청한 리소스를 찾을 수 없습니다."),
+    CONFLICT(HttpStatus.CONFLICT, "CONFLICT", "이미 존재하는 리소스입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "서버 내부 오류가 발생했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    ApiErrorCode(HttpStatus httpStatus, String code, String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/common/exception/ApiException.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/common/exception/ApiException.java
@@ -1,0 +1,22 @@
+package com.example.foodaiflatformserver.common.exception;
+
+import com.example.foodaiflatformserver.common.ApiErrorCode;
+
+public class ApiException extends RuntimeException {
+
+    private final ApiErrorCode errorCode;
+
+    public ApiException(ApiErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ApiException(ApiErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public ApiErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/common/exception/BadRequestException.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/common/exception/BadRequestException.java
@@ -1,0 +1,14 @@
+package com.example.foodaiflatformserver.common.exception;
+
+import com.example.foodaiflatformserver.common.ApiErrorCode;
+
+public class BadRequestException extends ApiException {
+
+    public BadRequestException() {
+        super(ApiErrorCode.INVALID_REQUEST);
+    }
+
+    public BadRequestException(String message) {
+        super(ApiErrorCode.INVALID_REQUEST, message);
+    }
+}

--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/common/exception/ConflictException.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/common/exception/ConflictException.java
@@ -1,0 +1,14 @@
+package com.example.foodaiflatformserver.common.exception;
+
+import com.example.foodaiflatformserver.common.ApiErrorCode;
+
+public class ConflictException extends ApiException {
+
+    public ConflictException() {
+        super(ApiErrorCode.CONFLICT);
+    }
+
+    public ConflictException(String message) {
+        super(ApiErrorCode.CONFLICT, message);
+    }
+}

--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/common/exception/ForbiddenException.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/common/exception/ForbiddenException.java
@@ -1,0 +1,14 @@
+package com.example.foodaiflatformserver.common.exception;
+
+import com.example.foodaiflatformserver.common.ApiErrorCode;
+
+public class ForbiddenException extends ApiException {
+
+    public ForbiddenException() {
+        super(ApiErrorCode.FORBIDDEN);
+    }
+
+    public ForbiddenException(String message) {
+        super(ApiErrorCode.FORBIDDEN, message);
+    }
+}

--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/common/exception/NotFoundException.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/common/exception/NotFoundException.java
@@ -1,0 +1,14 @@
+package com.example.foodaiflatformserver.common.exception;
+
+import com.example.foodaiflatformserver.common.ApiErrorCode;
+
+public class NotFoundException extends ApiException {
+
+    public NotFoundException() {
+        super(ApiErrorCode.NOT_FOUND);
+    }
+
+    public NotFoundException(String message) {
+        super(ApiErrorCode.NOT_FOUND, message);
+    }
+}

--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/common/exception/UnauthorizedException.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/common/exception/UnauthorizedException.java
@@ -1,0 +1,14 @@
+package com.example.foodaiflatformserver.common.exception;
+
+import com.example.foodaiflatformserver.common.ApiErrorCode;
+
+public class UnauthorizedException extends ApiException {
+
+    public UnauthorizedException() {
+        super(ApiErrorCode.UNAUTHORIZED);
+    }
+
+    public UnauthorizedException(String message) {
+        super(ApiErrorCode.UNAUTHORIZED, message);
+    }
+}

--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/common/handler/GlobalExceptionHandler.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/common/handler/GlobalExceptionHandler.java
@@ -1,0 +1,75 @@
+package com.example.foodaiflatformserver.common.handler;
+
+import com.example.foodaiflatformserver.common.ApiErrorCode;
+import com.example.foodaiflatformserver.common.exception.ApiException;
+import com.example.foodaiflatformserver.common.response.ApiErrorDetail;
+import com.example.foodaiflatformserver.common.response.ApiErrorResponse;
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.util.Comparator;
+import java.util.List;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ApiException.class)
+    public ResponseEntity<ApiErrorResponse> handleApiException(ApiException exception) {
+        ApiErrorCode errorCode = exception.getErrorCode();
+
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(ApiErrorResponse.of(errorCode, exception.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiErrorResponse> handleMethodArgumentNotValid(MethodArgumentNotValidException exception) {
+        List<ApiErrorDetail> details = exception.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .sorted(Comparator.comparing(FieldError::getField))
+                .map(fieldError -> new ApiErrorDetail(fieldError.getField(), fieldError.getDefaultMessage()))
+                .toList();
+
+        return badRequest(ApiErrorCode.INVALID_REQUEST.getMessage(), details);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ApiErrorResponse> handleConstraintViolation(ConstraintViolationException exception) {
+        List<ApiErrorDetail> details = exception.getConstraintViolations()
+                .stream()
+                .map(violation -> new ApiErrorDetail(violation.getPropertyPath().toString(), violation.getMessage()))
+                .toList();
+
+        return badRequest(ApiErrorCode.INVALID_REQUEST.getMessage(), details);
+    }
+
+    @ExceptionHandler({
+            HttpMessageNotReadableException.class,
+            MethodArgumentTypeMismatchException.class
+    })
+    public ResponseEntity<ApiErrorResponse> handleRequestParsingException(Exception exception) {
+        return badRequest(ApiErrorCode.INVALID_REQUEST.getMessage(), List.of());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiErrorResponse> handleUnexpectedException(Exception exception) {
+        ApiErrorCode errorCode = ApiErrorCode.INTERNAL_SERVER_ERROR;
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiErrorResponse.of(errorCode, errorCode.getMessage()));
+    }
+
+    private ResponseEntity<ApiErrorResponse> badRequest(String message, List<ApiErrorDetail> details) {
+        ApiErrorCode errorCode = ApiErrorCode.INVALID_REQUEST;
+
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(ApiErrorResponse.of(errorCode, message, details));
+    }
+}

--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/common/response/ApiErrorDetail.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/common/response/ApiErrorDetail.java
@@ -1,0 +1,7 @@
+package com.example.foodaiflatformserver.common.response;
+
+public record ApiErrorDetail(
+        String field,
+        String reason
+) {
+}

--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/common/response/ApiErrorResponse.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/common/response/ApiErrorResponse.java
@@ -1,0 +1,33 @@
+package com.example.foodaiflatformserver.common.response;
+
+import com.example.foodaiflatformserver.common.ApiErrorCode;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ApiErrorResponse(
+        LocalDateTime timestamp,
+        int status,
+        String code,
+        String message,
+        List<ApiErrorDetail> details
+) {
+
+    public static ApiErrorResponse of(ApiErrorCode errorCode, String message, List<ApiErrorDetail> details) {
+        return new ApiErrorResponse(
+                LocalDateTime.now(),
+                errorCode.getHttpStatus().value(),
+                errorCode.getCode(),
+                message,
+                details
+        );
+    }
+
+    public static ApiErrorResponse of(ApiErrorCode errorCode, List<ApiErrorDetail> details) {
+        return of(errorCode, errorCode.getMessage(), details);
+    }
+
+    public static ApiErrorResponse of(ApiErrorCode errorCode, String message) {
+        return of(errorCode, message, List.of());
+    }
+}

--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/fridgeitem/package-info.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/fridgeitem/package-info.java
@@ -1,0 +1,1 @@
+package com.example.foodaiflatformserver.fridgeitem;

--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/recipe/package-info.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/recipe/package-info.java
@@ -1,0 +1,1 @@
+package com.example.foodaiflatformserver.recipe;

--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/user/package-info.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/user/package-info.java
@@ -1,0 +1,1 @@
+package com.example.foodaiflatformserver.user;

--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/userrecipe/package-info.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/userrecipe/package-info.java
@@ -1,0 +1,1 @@
+package com.example.foodaiflatformserver.userrecipe;

--- a/food-ai-flatform-server/src/test/java/com/example/foodaiflatformserver/common/handler/GlobalExceptionHandlerTest.java
+++ b/food-ai-flatform-server/src/test/java/com/example/foodaiflatformserver/common/handler/GlobalExceptionHandlerTest.java
@@ -1,0 +1,72 @@
+package com.example.foodaiflatformserver.common.handler;
+
+import com.example.foodaiflatformserver.common.exception.NotFoundException;
+import com.example.foodaiflatformserver.common.response.ApiErrorResponse;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GlobalExceptionHandlerTest {
+
+    private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+    @DisplayName("검증 실패는 API_SPEC 공통 오류 응답 형식으로 반환한다")
+    @Test
+    void returnsValidationErrorResponse() throws NoSuchMethodException {
+        TestRequest request = new TestRequest("not-an-email", "");
+        BeanPropertyBindingResult bindingResult = new BeanPropertyBindingResult(request, "request");
+        bindingResult.addError(new FieldError("request", "email", "이메일 형식이 올바르지 않습니다."));
+        bindingResult.addError(new FieldError("request", "name", "이름은 필수입니다."));
+
+        Method method = TestController.class.getDeclaredMethod("validate", TestRequest.class);
+        MethodParameter methodParameter = new MethodParameter(method, 0);
+        MethodArgumentNotValidException exception = new MethodArgumentNotValidException(methodParameter, bindingResult);
+
+        ResponseEntity<ApiErrorResponse> response = handler.handleMethodArgumentNotValid(exception);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(400);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().status()).isEqualTo(400);
+        assertThat(response.getBody().code()).isEqualTo("INVALID_REQUEST");
+        assertThat(response.getBody().message()).isEqualTo("요청 값이 올바르지 않습니다.");
+        assertThat(response.getBody().details()).hasSize(2);
+        assertThat(response.getBody().details().get(0).field()).isEqualTo("email");
+        assertThat(response.getBody().details().get(0).reason()).isEqualTo("이메일 형식이 올바르지 않습니다.");
+        assertThat(response.getBody().details().get(1).field()).isEqualTo("name");
+        assertThat(response.getBody().details().get(1).reason()).isEqualTo("이름은 필수입니다.");
+    }
+
+    @DisplayName("도메인 예외는 API_SPEC 공통 오류 응답 형식으로 반환한다")
+    @Test
+    void returnsDomainExceptionResponse() {
+        ResponseEntity<ApiErrorResponse> response = handler.handleApiException(new NotFoundException("식재료를 찾을 수 없습니다."));
+
+        assertThat(response.getStatusCode().value()).isEqualTo(404);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().status()).isEqualTo(404);
+        assertThat(response.getBody().code()).isEqualTo("NOT_FOUND");
+        assertThat(response.getBody().message()).isEqualTo("식재료를 찾을 수 없습니다.");
+        assertThat(response.getBody().details()).isEmpty();
+    }
+
+    static class TestController {
+        void validate(TestRequest request) {
+        }
+    }
+
+    record TestRequest(
+            @Email(message = "이메일 형식이 올바르지 않습니다.") String email,
+            @NotBlank(message = "이름은 필수입니다.") String name
+    ) {
+    }
+}


### PR DESCRIPTION
## 목적
도메인 API 구현 전에 백엔드 기본 구조와 공통 응답/예외 처리 방식을 정리한다.

## 작업 내용
- 패키지 구조 정의
  - `common`
  - `auth`
  - `fridgeitem`
  - `user`
  - `recipe`
  - `userrecipe`
- 공통 오류 응답 DTO 정의
- 글로벌 예외 핸들러 구현
- Validation 실패 응답 형식 통일
- 공통 에러 코드 정의
  - `INVALID_REQUEST`
  - `UNAUTHORIZED`
  - `FORBIDDEN`
  - `NOT_FOUND`
  - `CONFLICT`
  - `INTERNAL_SERVER_ERROR`

## 완료 조건
- 예외 발생 시 모든 API가 동일한 JSON 형식으로 응답한다
- Validation 에러가 필드 단위로 반환된다
- 이후 도메인 API 구현이 가능한 기본 구조가 준비된다
