### PR TITLE
[BE] DB 스키마 및 JPA 엔티티 설계

### DIFF
--- a/food-ai-flatform-server/build.gradle
+++ b/food-ai-flatform-server/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testCompileOnly 'org.projectlombok:lombok'
+    testRuntimeOnly 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testAnnotationProcessor 'org.projectlombok:lombok'
 }

--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/fridgeitem/entity/FridgeItem.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/fridgeitem/entity/FridgeItem.java
@@ -1,0 +1,82 @@
+package com.example.foodaiflatformserver.fridgeitem.entity;
+
+import com.example.foodaiflatformserver.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import jakarta.persistence.Index;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@Entity
+@Table(
+        name = "fridge_items",
+        indexes = {
+                @Index(name = "idx_fridge_items_user_id", columnList = "user_id"),
+                @Index(name = "idx_fridge_items_expiration_date", columnList = "expiration_date")
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FridgeItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "item_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(nullable = false, length = 50)
+    private String quantity;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "storage_location", nullable = false, length = 20)
+    private StorageLocation storageLocation;
+
+    @Column(name = "registered_date", nullable = false)
+    private LocalDate registeredDate;
+
+    @Column(name = "expiration_date", nullable = false)
+    private LocalDate expirationDate;
+
+    @Builder
+    public FridgeItem(User user, String name, String quantity, StorageLocation storageLocation, LocalDate registeredDate,
+                      LocalDate expirationDate) {
+        this.user = user;
+        this.name = name;
+        this.quantity = quantity;
+        this.storageLocation = storageLocation;
+        this.registeredDate = registeredDate;
+        this.expirationDate = expirationDate;
+    }
+
+    @PrePersist
+    void prePersist() {
+        if (registeredDate == null) {
+            registeredDate = LocalDate.now();
+        }
+    }
+
+    public void assignUser(User user) {
+        this.user = user;
+    }
+}

--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/fridgeitem/entity/StorageLocation.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/fridgeitem/entity/StorageLocation.java
@@ -1,0 +1,7 @@
+package com.example.foodaiflatformserver.fridgeitem.entity;
+
+public enum StorageLocation {
+    REFRIGERATED,
+    FROZEN,
+    ROOM_TEMP
+}

--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/user/entity/DifficultyPreference.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/user/entity/DifficultyPreference.java
@@ -1,0 +1,7 @@
+package com.example.foodaiflatformserver.user.entity;
+
+public enum DifficultyPreference {
+    EASY,
+    NORMAL,
+    HARD
+}

--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/user/entity/FavoriteCuisine.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/user/entity/FavoriteCuisine.java
@@ -1,0 +1,8 @@
+package com.example.foodaiflatformserver.user.entity;
+
+public enum FavoriteCuisine {
+    KOREAN,
+    JAPANESE,
+    WESTERN,
+    CHINESE
+}

--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/user/entity/User.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/user/entity/User.java
@@ -1,0 +1,78 @@
+package com.example.foodaiflatformserver.user.entity;
+
+import com.example.foodaiflatformserver.fridgeitem.entity.FridgeItem;
+import com.example.foodaiflatformserver.userrecipe.entity.UserRecipe;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Entity
+@Table(
+        name = "users",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_users_email", columnNames = "email")
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String username;
+
+    @Column(nullable = false, length = 255)
+    private String email;
+
+    @Column(nullable = false, length = 255)
+    private String password;
+
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private UserPreference preference;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private final List<FridgeItem> fridgeItems = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private final List<UserRecipe> userRecipes = new ArrayList<>();
+
+    @Builder
+    public User(String username, String email, String password) {
+        this.username = username;
+        this.email = email;
+        this.password = password;
+    }
+
+    public void assignPreference(UserPreference preference) {
+        this.preference = preference;
+        preference.assignUser(this);
+    }
+
+    public void addFridgeItem(FridgeItem fridgeItem) {
+        fridgeItems.add(fridgeItem);
+        fridgeItem.assignUser(this);
+    }
+
+    public void addUserRecipe(UserRecipe userRecipe) {
+        userRecipes.add(userRecipe);
+        userRecipe.assignUser(this);
+    }
+}

--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/user/entity/UserPreference.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/user/entity/UserPreference.java
@@ -1,0 +1,86 @@
+package com.example.foodaiflatformserver.user.entity;
+
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+@Getter
+@Entity
+@Table(
+        name = "user_preferences",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_user_preferences_user_id", columnNames = "user_id")
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserPreference {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_preference_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ElementCollection
+    @CollectionTable(
+            name = "user_preference_favorite_cuisines",
+            joinColumns = @JoinColumn(name = "user_preference_id", nullable = false)
+    )
+    @Column(name = "favorite_cuisine", nullable = false, length = 20)
+    @Enumerated(EnumType.STRING)
+    private Set<FavoriteCuisine> favoriteCuisines = new LinkedHashSet<>();
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "difficulty_preference", nullable = false, length = 20)
+    private DifficultyPreference difficultyPreference;
+
+    @Column(name = "quick_meal_preferred", nullable = false)
+    private boolean quickMealPreferred;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public UserPreference(Set<FavoriteCuisine> favoriteCuisines, DifficultyPreference difficultyPreference,
+                          boolean quickMealPreferred) {
+        if (favoriteCuisines != null) {
+            this.favoriteCuisines = new LinkedHashSet<>(favoriteCuisines);
+        }
+        this.difficultyPreference = difficultyPreference;
+        this.quickMealPreferred = quickMealPreferred;
+    }
+
+    @PrePersist
+    @PreUpdate
+    void touchUpdatedAt() {
+        updatedAt = LocalDateTime.now();
+    }
+
+    public void assignUser(User user) {
+        this.user = user;
+    }
+}

--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/userrecipe/entity/UserRecipe.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/userrecipe/entity/UserRecipe.java
@@ -1,0 +1,74 @@
+package com.example.foodaiflatformserver.userrecipe.entity;
+
+import com.example.foodaiflatformserver.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(
+        name = "user_recipes",
+        indexes = {
+                @Index(name = "idx_user_recipes_user_id", columnList = "user_id"),
+                @Index(name = "idx_user_recipes_selected_at", columnList = "selected_at")
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserRecipe {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "history_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "recipe_id", nullable = false)
+    private Long recipeId;
+
+    @Column(name = "recipe_name", nullable = false, length = 100)
+    private String recipeName;
+
+    @Column(nullable = false, length = 50)
+    private String category;
+
+    @Column(name = "selected_at", nullable = false)
+    private LocalDateTime selectedAt;
+
+    @Builder
+    public UserRecipe(User user, Long recipeId, String recipeName, String category, LocalDateTime selectedAt) {
+        this.user = user;
+        this.recipeId = recipeId;
+        this.recipeName = recipeName;
+        this.category = category;
+        this.selectedAt = selectedAt;
+    }
+
+    @PrePersist
+    void prePersist() {
+        if (selectedAt == null) {
+            selectedAt = LocalDateTime.now();
+        }
+    }
+
+    public void assignUser(User user) {
+        this.user = user;
+    }
+}

--- a/food-ai-flatform-server/src/test/resources/application.properties
+++ b/food-ai-flatform-server/src/test/resources/application.properties
@@ -1,0 +1,8 @@
+spring.datasource.url=jdbc:h2:mem:food_ai_platform;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.username=sa
+spring.datasource.password=
+spring.datasource.driver-class-name=org.h2.Driver
+
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.open-in-view=false
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
## 목적
현재 API 스펙을 기준으로 핵심 테이블과 엔티티를 설계한다.

## 작업 내용
- `users` 엔티티 설계
- `fridge_items` 엔티티 설계
- `user_preferences` 엔티티 설계
- `user_recipes` 엔티티 설계
- 연관관계 정의
- 이메일 unique, FK, null 제약 검토
- enum 매핑 전략 검토

## 완료 조건
- 핵심 엔티티가 API 스펙을 충족한다
- JPA 매핑 오류 없이 애플리케이션이 기동된다
- 이후 인증/도메인 API 구현이 가능하다
