### PR TITLE
Feat/issue 18 fridge item write api

### DIFF
--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/fridgeitem/controller/FridgeItemController.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/fridgeitem/controller/FridgeItemController.java
@@ -1,0 +1,53 @@
+package com.example.foodaiflatformserver.fridgeitem.controller;
+
+import com.example.foodaiflatformserver.auth.security.UserPrincipal;
+import com.example.foodaiflatformserver.fridgeitem.dto.FridgeItemResponse;
+import com.example.foodaiflatformserver.fridgeitem.dto.FridgeItemSaveRequest;
+import com.example.foodaiflatformserver.fridgeitem.service.FridgeItemService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/fridge-items")
+@RequiredArgsConstructor
+public class FridgeItemController {
+
+    private final FridgeItemService fridgeItemService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public FridgeItemResponse create(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody FridgeItemSaveRequest request
+    ) {
+        return fridgeItemService.create(principal, request);
+    }
+
+    @PutMapping("/{itemId}")
+    public FridgeItemResponse update(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long itemId,
+            @Valid @RequestBody FridgeItemSaveRequest request
+    ) {
+        return fridgeItemService.update(principal, itemId, request);
+    }
+
+    @DeleteMapping("/{itemId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long itemId
+    ) {
+        fridgeItemService.delete(principal, itemId);
+    }
+}

--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/fridgeitem/dto/FridgeItemResponse.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/fridgeitem/dto/FridgeItemResponse.java
@@ -1,0 +1,54 @@
+package com.example.foodaiflatformserver.fridgeitem.dto;
+
+import com.example.foodaiflatformserver.fridgeitem.entity.FridgeItem;
+import com.example.foodaiflatformserver.fridgeitem.service.FridgeItemStatusCalculator;
+import com.example.foodaiflatformserver.fridgeitem.service.FridgeItemStatusResult;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.LocalDate;
+
+public record FridgeItemResponse(
+        @JsonProperty("item_id")
+        Long itemId,
+
+        @JsonProperty("name")
+        String name,
+
+        @JsonProperty("quantity")
+        String quantity,
+
+        @JsonProperty("storage_location")
+        String storageLocation,
+
+        @JsonProperty("registered_date")
+        LocalDate registeredDate,
+
+        @JsonProperty("expiration_date")
+        LocalDate expirationDate,
+
+        @JsonProperty("status")
+        String status,
+
+        @JsonProperty("d_day")
+        int dDay,
+
+        @JsonProperty("status_text")
+        String statusText
+) {
+
+    public static FridgeItemResponse from(FridgeItem fridgeItem, FridgeItemStatusCalculator statusCalculator) {
+        FridgeItemStatusResult statusResult = statusCalculator.calculate(fridgeItem.getExpirationDate());
+
+        return new FridgeItemResponse(
+                fridgeItem.getId(),
+                fridgeItem.getName(),
+                fridgeItem.getQuantity(),
+                fridgeItem.getStorageLocation().name(),
+                fridgeItem.getRegisteredDate(),
+                fridgeItem.getExpirationDate(),
+                statusResult.status().name(),
+                statusResult.dDay(),
+                statusResult.statusText()
+        );
+    }
+}

--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/fridgeitem/dto/FridgeItemSaveRequest.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/fridgeitem/dto/FridgeItemSaveRequest.java
@@ -4,16 +4,19 @@ import com.example.foodaiflatformserver.fridgeitem.entity.StorageLocation;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 import java.time.LocalDate;
 
 public record FridgeItemSaveRequest(
         @JsonProperty("name")
         @NotBlank(message = "식품명은 필수입니다.")
+        @Size(max = 100, message = "식품명은 100자 이하여야 합니다.")
         String name,
 
         @JsonProperty("quantity")
         @NotBlank(message = "수량은 필수입니다.")
+        @Size(max = 50, message = "수량은 50자 이하여야 합니다.")
         String quantity,
 
         @JsonProperty("storage_location")

--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/fridgeitem/dto/FridgeItemSaveRequest.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/fridgeitem/dto/FridgeItemSaveRequest.java
@@ -1,0 +1,27 @@
+package com.example.foodaiflatformserver.fridgeitem.dto;
+
+import com.example.foodaiflatformserver.fridgeitem.entity.StorageLocation;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+public record FridgeItemSaveRequest(
+        @JsonProperty("name")
+        @NotBlank(message = "식품명은 필수입니다.")
+        String name,
+
+        @JsonProperty("quantity")
+        @NotBlank(message = "수량은 필수입니다.")
+        String quantity,
+
+        @JsonProperty("storage_location")
+        @NotNull(message = "보관 위치는 필수입니다.")
+        StorageLocation storageLocation,
+
+        @JsonProperty("expiration_date")
+        @NotNull(message = "유통기한은 필수입니다.")
+        LocalDate expirationDate
+) {
+}

--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/fridgeitem/entity/FridgeItem.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/fridgeitem/entity/FridgeItem.java
@@ -79,4 +79,11 @@ public class FridgeItem {
     public void assignUser(User user) {
         this.user = user;
     }
+
+    public void update(String name, String quantity, StorageLocation storageLocation, LocalDate expirationDate) {
+        this.name = name;
+        this.quantity = quantity;
+        this.storageLocation = storageLocation;
+        this.expirationDate = expirationDate;
+    }
 }

--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/fridgeitem/entity/ItemStatus.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/fridgeitem/entity/ItemStatus.java
@@ -1,0 +1,7 @@
+package com.example.foodaiflatformserver.fridgeitem.entity;
+
+public enum ItemStatus {
+    OK,
+    WARNING,
+    EXPIRED
+}

--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/fridgeitem/repository/FridgeItemRepository.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/fridgeitem/repository/FridgeItemRepository.java
@@ -1,0 +1,7 @@
+package com.example.foodaiflatformserver.fridgeitem.repository;
+
+import com.example.foodaiflatformserver.fridgeitem.entity.FridgeItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FridgeItemRepository extends JpaRepository<FridgeItem, Long> {
+}

--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/fridgeitem/service/FridgeItemService.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/fridgeitem/service/FridgeItemService.java
@@ -1,0 +1,82 @@
+package com.example.foodaiflatformserver.fridgeitem.service;
+
+import com.example.foodaiflatformserver.auth.security.UserPrincipal;
+import com.example.foodaiflatformserver.common.exception.ForbiddenException;
+import com.example.foodaiflatformserver.common.exception.NotFoundException;
+import com.example.foodaiflatformserver.fridgeitem.dto.FridgeItemResponse;
+import com.example.foodaiflatformserver.fridgeitem.dto.FridgeItemSaveRequest;
+import com.example.foodaiflatformserver.fridgeitem.entity.FridgeItem;
+import com.example.foodaiflatformserver.fridgeitem.repository.FridgeItemRepository;
+import com.example.foodaiflatformserver.user.entity.User;
+import com.example.foodaiflatformserver.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FridgeItemService {
+
+    private final FridgeItemRepository fridgeItemRepository;
+    private final UserRepository userRepository;
+    private final FridgeItemStatusCalculator statusCalculator;
+
+    @Transactional
+    public FridgeItemResponse create(UserPrincipal principal, FridgeItemSaveRequest request) {
+        User user = getUser(principal.id());
+
+        FridgeItem fridgeItem = FridgeItem.builder()
+                .user(user)
+                .name(normalize(request.name()))
+                .quantity(normalize(request.quantity()))
+                .storageLocation(request.storageLocation())
+                .registeredDate(LocalDate.now(FridgeItemStatusCalculator.BUSINESS_ZONE))
+                .expirationDate(request.expirationDate())
+                .build();
+
+        FridgeItem savedItem = fridgeItemRepository.save(fridgeItem);
+        return FridgeItemResponse.from(savedItem, statusCalculator);
+    }
+
+    @Transactional
+    public FridgeItemResponse update(UserPrincipal principal, Long itemId, FridgeItemSaveRequest request) {
+        FridgeItem fridgeItem = getOwnedFridgeItem(principal.id(), itemId);
+        fridgeItem.update(
+                normalize(request.name()),
+                normalize(request.quantity()),
+                request.storageLocation(),
+                request.expirationDate()
+        );
+
+        return FridgeItemResponse.from(fridgeItem, statusCalculator);
+    }
+
+    @Transactional
+    public void delete(UserPrincipal principal, Long itemId) {
+        FridgeItem fridgeItem = getOwnedFridgeItem(principal.id(), itemId);
+        fridgeItemRepository.delete(fridgeItem);
+    }
+
+    private User getUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException("사용자를 찾을 수 없습니다."));
+    }
+
+    private FridgeItem getOwnedFridgeItem(Long userId, Long itemId) {
+        FridgeItem fridgeItem = fridgeItemRepository.findById(itemId)
+                .orElseThrow(() -> new NotFoundException("식재료를 찾을 수 없습니다."));
+
+        if (!fridgeItem.getUser().getId().equals(userId)) {
+            throw new ForbiddenException("다른 사용자의 식재료에는 접근할 수 없습니다.");
+        }
+
+        return fridgeItem;
+    }
+
+    private String normalize(String value) {
+        return value.trim().replaceAll("\\s+", " ");
+    }
+}

--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/fridgeitem/service/FridgeItemStatusCalculator.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/fridgeitem/service/FridgeItemStatusCalculator.java
@@ -1,0 +1,65 @@
+package com.example.foodaiflatformserver.fridgeitem.service;
+
+import com.example.foodaiflatformserver.fridgeitem.entity.ItemStatus;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
+
+@Component
+public class FridgeItemStatusCalculator {
+
+    public static final ZoneId BUSINESS_ZONE = ZoneId.of("Asia/Seoul");
+
+    private final Clock clock;
+
+    public FridgeItemStatusCalculator() {
+        this(Clock.system(BUSINESS_ZONE));
+    }
+
+    FridgeItemStatusCalculator(Clock clock) {
+        this.clock = Objects.requireNonNull(clock);
+    }
+
+    public FridgeItemStatusResult calculate(LocalDate expirationDate) {
+        int dDay = calculateDDay(expirationDate);
+
+        return new FridgeItemStatusResult(
+                dDay,
+                toStatusText(dDay),
+                toStatus(dDay)
+        );
+    }
+
+    public int calculateDDay(LocalDate expirationDate) {
+        LocalDate today = LocalDate.now(clock);
+        return Math.toIntExact(ChronoUnit.DAYS.between(today, requireExpirationDate(expirationDate)));
+    }
+
+    private LocalDate requireExpirationDate(LocalDate expirationDate) {
+        return Objects.requireNonNull(expirationDate, "expirationDate must not be null");
+    }
+
+    private ItemStatus toStatus(int dDay) {
+        if (dDay < 0) {
+            return ItemStatus.EXPIRED;
+        }
+        if (dDay <= 3) {
+            return ItemStatus.WARNING;
+        }
+        return ItemStatus.OK;
+    }
+
+    private String toStatusText(int dDay) {
+        if (dDay < 0) {
+            return Math.abs(dDay) + "일 지남";
+        }
+        if (dDay == 0) {
+            return "오늘 만료";
+        }
+        return "D-" + dDay;
+    }
+}

--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/fridgeitem/service/FridgeItemStatusResult.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/fridgeitem/service/FridgeItemStatusResult.java
@@ -1,0 +1,10 @@
+package com.example.foodaiflatformserver.fridgeitem.service;
+
+import com.example.foodaiflatformserver.fridgeitem.entity.ItemStatus;
+
+public record FridgeItemStatusResult(
+        int dDay,
+        String statusText,
+        ItemStatus status
+) {
+}

--- a/food-ai-flatform-server/src/test/java/com/example/foodaiflatformserver/domain/DomainEnumConsistencyTest.java
+++ b/food-ai-flatform-server/src/test/java/com/example/foodaiflatformserver/domain/DomainEnumConsistencyTest.java
@@ -1,0 +1,45 @@
+package com.example.foodaiflatformserver.domain;
+
+import com.example.foodaiflatformserver.fridgeitem.entity.ItemStatus;
+import com.example.foodaiflatformserver.fridgeitem.entity.StorageLocation;
+import com.example.foodaiflatformserver.user.entity.DifficultyPreference;
+import com.example.foodaiflatformserver.user.entity.FavoriteCuisine;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DomainEnumConsistencyTest {
+
+    @DisplayName("보관 위치 enum은 API 스펙 값과 일치한다")
+    @Test
+    void storageLocationMatchesApiSpec() {
+        assertThat(StorageLocation.values())
+                .extracting(Enum::name)
+                .containsExactly("REFRIGERATED", "FROZEN", "ROOM_TEMP");
+    }
+
+    @DisplayName("식품 상태 enum은 API 스펙 값과 일치한다")
+    @Test
+    void itemStatusMatchesApiSpec() {
+        assertThat(ItemStatus.values())
+                .extracting(Enum::name)
+                .containsExactly("OK", "WARNING", "EXPIRED");
+    }
+
+    @DisplayName("선호 요리 enum은 API 스펙 값과 일치한다")
+    @Test
+    void favoriteCuisineMatchesApiSpec() {
+        assertThat(FavoriteCuisine.values())
+                .extracting(Enum::name)
+                .containsExactly("KOREAN", "JAPANESE", "WESTERN", "CHINESE");
+    }
+
+    @DisplayName("난이도 enum은 API 스펙 값과 일치한다")
+    @Test
+    void difficultyPreferenceMatchesApiSpec() {
+        assertThat(DifficultyPreference.values())
+                .extracting(Enum::name)
+                .containsExactly("EASY", "NORMAL", "HARD");
+    }
+}

--- a/food-ai-flatform-server/src/test/java/com/example/foodaiflatformserver/fridgeitem/controller/FridgeItemControllerTest.java
+++ b/food-ai-flatform-server/src/test/java/com/example/foodaiflatformserver/fridgeitem/controller/FridgeItemControllerTest.java
@@ -1,0 +1,247 @@
+package com.example.foodaiflatformserver.fridgeitem.controller;
+
+import com.example.foodaiflatformserver.fridgeitem.entity.FridgeItem;
+import com.example.foodaiflatformserver.fridgeitem.entity.StorageLocation;
+import com.example.foodaiflatformserver.fridgeitem.repository.FridgeItemRepository;
+import com.example.foodaiflatformserver.fridgeitem.service.FridgeItemStatusCalculator;
+import com.example.foodaiflatformserver.user.entity.User;
+import com.example.foodaiflatformserver.user.repository.UserRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.time.LocalDate;
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
+
+@SpringBootTest
+class FridgeItemControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private FridgeItemRepository fridgeItemRepository;
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = webAppContextSetup(webApplicationContext)
+                .apply(springSecurity())
+                .build();
+        fridgeItemRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @DisplayName("식재료 등록에 성공하면 201과 생성된 식재료를 반환한다")
+    @Test
+    void createFridgeItem() throws Exception {
+        String accessToken = signupAndLogin("user@example.com");
+        LocalDate expirationDate = LocalDate.now(FridgeItemStatusCalculator.BUSINESS_ZONE).plusDays(13);
+
+        mockMvc.perform(post("/api/v1/fridge-items")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name": "우유",
+                                  "quantity": "500ml",
+                                  "storage_location": "REFRIGERATED",
+                                  "expiration_date": "%s"
+                                }
+                                """.formatted(expirationDate)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.item_id").isNumber())
+                .andExpect(jsonPath("$.name").value("우유"))
+                .andExpect(jsonPath("$.quantity").value("500ml"))
+                .andExpect(jsonPath("$.storage_location").value("REFRIGERATED"))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.d_day").value(13))
+                .andExpect(jsonPath("$.status_text").value("D-13"));
+    }
+
+    @DisplayName("본인 식재료 수정에 성공하면 200과 수정된 식재료를 반환한다")
+    @Test
+    void updateOwnedFridgeItem() throws Exception {
+        String accessToken = signupAndLogin("user@example.com");
+        User user = userRepository.findByEmail("user@example.com").orElseThrow();
+        FridgeItem fridgeItem = fridgeItemRepository.save(FridgeItem.builder()
+                .user(user)
+                .name("우유")
+                .quantity("500ml")
+                .storageLocation(StorageLocation.REFRIGERATED)
+                .registeredDate(LocalDate.of(2026, 5, 1))
+                .expirationDate(LocalDate.now(FridgeItemStatusCalculator.BUSINESS_ZONE).plusDays(5))
+                .build());
+
+        LocalDate updatedExpirationDate = LocalDate.now(FridgeItemStatusCalculator.BUSINESS_ZONE).plusDays(14);
+
+        mockMvc.perform(put("/api/v1/fridge-items/{itemId}", fridgeItem.getId())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name": "저지방 우유",
+                                  "quantity": "450ml",
+                                  "storage_location": "REFRIGERATED",
+                                  "expiration_date": "%s"
+                                }
+                                """.formatted(updatedExpirationDate)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.item_id").value(fridgeItem.getId()))
+                .andExpect(jsonPath("$.name").value("저지방 우유"))
+                .andExpect(jsonPath("$.quantity").value("450ml"))
+                .andExpect(jsonPath("$.registered_date").value("2026-05-01"))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.d_day").value(14))
+                .andExpect(jsonPath("$.status_text").value("D-14"));
+    }
+
+    @DisplayName("타인의 식재료 수정은 403을 반환한다")
+    @Test
+    void updateOtherUsersFridgeItemFails() throws Exception {
+        String accessToken = signupAndLogin("user@example.com");
+        signupAndLogin("other@example.com");
+
+        User otherUser = userRepository.findByEmail("other@example.com").orElseThrow();
+        FridgeItem fridgeItem = fridgeItemRepository.save(FridgeItem.builder()
+                .user(otherUser)
+                .name("사과")
+                .quantity("2개")
+                .storageLocation(StorageLocation.ROOM_TEMP)
+                .expirationDate(LocalDate.now(FridgeItemStatusCalculator.BUSINESS_ZONE).plusDays(2))
+                .build());
+
+        mockMvc.perform(put("/api/v1/fridge-items/{itemId}", fridgeItem.getId())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name": "청사과",
+                                  "quantity": "3개",
+                                  "storage_location": "ROOM_TEMP",
+                                  "expiration_date": "%s"
+                                }
+                                """.formatted(LocalDate.now(FridgeItemStatusCalculator.BUSINESS_ZONE).plusDays(3))))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("FORBIDDEN"));
+    }
+
+    @DisplayName("존재하지 않는 식재료 수정은 404를 반환한다")
+    @Test
+    void updateMissingFridgeItemFails() throws Exception {
+        String accessToken = signupAndLogin("user@example.com");
+
+        mockMvc.perform(put("/api/v1/fridge-items/{itemId}", 9999L)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name": "우유",
+                                  "quantity": "500ml",
+                                  "storage_location": "REFRIGERATED",
+                                  "expiration_date": "%s"
+                                }
+                                """.formatted(LocalDate.now(FridgeItemStatusCalculator.BUSINESS_ZONE).plusDays(5))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+    }
+
+    @DisplayName("본인 식재료 삭제에 성공하면 204를 반환한다")
+    @Test
+    void deleteOwnedFridgeItem() throws Exception {
+        String accessToken = signupAndLogin("user@example.com");
+        User user = userRepository.findByEmail("user@example.com").orElseThrow();
+        FridgeItem fridgeItem = fridgeItemRepository.save(FridgeItem.builder()
+                .user(user)
+                .name("우유")
+                .quantity("500ml")
+                .storageLocation(StorageLocation.REFRIGERATED)
+                .expirationDate(LocalDate.now(FridgeItemStatusCalculator.BUSINESS_ZONE).plusDays(5))
+                .build());
+
+        mockMvc.perform(delete("/api/v1/fridge-items/{itemId}", fridgeItem.getId())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isNoContent());
+    }
+
+    @DisplayName("타인의 식재료 삭제는 403을 반환한다")
+    @Test
+    void deleteOtherUsersFridgeItemFails() throws Exception {
+        String accessToken = signupAndLogin("user@example.com");
+        signupAndLogin("other@example.com");
+
+        User otherUser = userRepository.findByEmail("other@example.com").orElseThrow();
+        FridgeItem fridgeItem = fridgeItemRepository.save(FridgeItem.builder()
+                .user(otherUser)
+                .name("사과")
+                .quantity("2개")
+                .storageLocation(StorageLocation.ROOM_TEMP)
+                .expirationDate(LocalDate.now(FridgeItemStatusCalculator.BUSINESS_ZONE).plusDays(2))
+                .build());
+
+        mockMvc.perform(delete("/api/v1/fridge-items/{itemId}", fridgeItem.getId())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("FORBIDDEN"));
+    }
+
+    @DisplayName("존재하지 않는 식재료 삭제는 404를 반환한다")
+    @Test
+    void deleteMissingFridgeItemFails() throws Exception {
+        String accessToken = signupAndLogin("user@example.com");
+
+        mockMvc.perform(delete("/api/v1/fridge-items/{itemId}", 9999L)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+    }
+
+    private String signupAndLogin(String email) throws Exception {
+        mockMvc.perform(post("/api/v1/auth/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                        {
+                          "username": "홍길동",
+                          "email": "%s",
+                          "password": "Password123!"
+                        }
+                        """.formatted(email)));
+
+        String loginResponse = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "email": "%s",
+                                  "password": "Password123!"
+                                }
+                                """.formatted(email)))
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        JsonNode jsonNode = objectMapper.readTree(loginResponse);
+        return jsonNode.get("access_token").asText();
+    }
+}

--- a/food-ai-flatform-server/src/test/java/com/example/foodaiflatformserver/fridgeitem/controller/FridgeItemControllerTest.java
+++ b/food-ai-flatform-server/src/test/java/com/example/foodaiflatformserver/fridgeitem/controller/FridgeItemControllerTest.java
@@ -81,6 +81,36 @@ class FridgeItemControllerTest {
                 .andExpect(jsonPath("$.status_text").value("D-13"));
     }
 
+    @DisplayName("식재료 등록 시 길이 제한을 넘으면 400을 반환한다")
+    @Test
+    void createFridgeItemRejectsTooLongFields() throws Exception {
+        String accessToken = signupAndLogin("user@example.com");
+        String longName = "가".repeat(101);
+        String longQuantity = "1".repeat(51);
+
+        mockMvc.perform(post("/api/v1/fridge-items")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name": "%s",
+                                  "quantity": "%s",
+                                  "storage_location": "REFRIGERATED",
+                                  "expiration_date": "%s"
+                                }
+                                """.formatted(
+                                longName,
+                                longQuantity,
+                                LocalDate.now(FridgeItemStatusCalculator.BUSINESS_ZONE).plusDays(13)
+                        )))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_REQUEST"))
+                .andExpect(jsonPath("$.details[0].field").value("name"))
+                .andExpect(jsonPath("$.details[0].reason").value("식품명은 100자 이하여야 합니다."))
+                .andExpect(jsonPath("$.details[1].field").value("quantity"))
+                .andExpect(jsonPath("$.details[1].reason").value("수량은 50자 이하여야 합니다."));
+    }
+
     @DisplayName("본인 식재료 수정에 성공하면 200과 수정된 식재료를 반환한다")
     @Test
     void updateOwnedFridgeItem() throws Exception {

--- a/food-ai-flatform-server/src/test/java/com/example/foodaiflatformserver/fridgeitem/service/FridgeItemStatusCalculatorTest.java
+++ b/food-ai-flatform-server/src/test/java/com/example/foodaiflatformserver/fridgeitem/service/FridgeItemStatusCalculatorTest.java
@@ -1,0 +1,61 @@
+package com.example.foodaiflatformserver.fridgeitem.service;
+
+import com.example.foodaiflatformserver.fridgeitem.entity.ItemStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FridgeItemStatusCalculatorTest {
+
+    private static final ZoneId ASIA_SEOUL = ZoneId.of("Asia/Seoul");
+    private static final Clock FIXED_CLOCK =
+            Clock.fixed(Instant.parse("2026-04-27T00:00:00Z"), ASIA_SEOUL);
+
+    private final FridgeItemStatusCalculator calculator = new FridgeItemStatusCalculator(FIXED_CLOCK);
+
+    @DisplayName("유통기한이 4일 이상 남았으면 OK와 D-day 텍스트를 반환한다")
+    @Test
+    void returnsOkForItemsWithEnoughDaysLeft() {
+        FridgeItemStatusResult result = calculator.calculate(LocalDate.of(2026, 5, 2));
+
+        assertThat(result.dDay()).isEqualTo(5);
+        assertThat(result.status()).isEqualTo(ItemStatus.OK);
+        assertThat(result.statusText()).isEqualTo("D-5");
+    }
+
+    @DisplayName("유통기한이 3일 이내면 WARNING 상태를 반환한다")
+    @Test
+    void returnsWarningForItemsExpiringSoon() {
+        FridgeItemStatusResult result = calculator.calculate(LocalDate.of(2026, 4, 30));
+
+        assertThat(result.dDay()).isEqualTo(3);
+        assertThat(result.status()).isEqualTo(ItemStatus.WARNING);
+        assertThat(result.statusText()).isEqualTo("D-3");
+    }
+
+    @DisplayName("오늘 만료되는 식품은 WARNING과 오늘 만료 텍스트를 반환한다")
+    @Test
+    void returnsTodayStatusTextForSameDayExpiration() {
+        FridgeItemStatusResult result = calculator.calculate(LocalDate.of(2026, 4, 27));
+
+        assertThat(result.dDay()).isZero();
+        assertThat(result.status()).isEqualTo(ItemStatus.WARNING);
+        assertThat(result.statusText()).isEqualTo("오늘 만료");
+    }
+
+    @DisplayName("유통기한이 지난 식품은 EXPIRED와 지난 일수 텍스트를 반환한다")
+    @Test
+    void returnsExpiredForPastExpiration() {
+        FridgeItemStatusResult result = calculator.calculate(LocalDate.of(2026, 4, 25));
+
+        assertThat(result.dDay()).isEqualTo(-2);
+        assertThat(result.status()).isEqualTo(ItemStatus.EXPIRED);
+        assertThat(result.statusText()).isEqualTo("2일 지남");
+    }
+}


### PR DESCRIPTION
## 목적
냉장고 식재료 관리의 쓰기 API를 구현한다.

## 작업 내용
- `POST /fridge-items`
- `PUT /fridge-items/{item_id}`
- `DELETE /fridge-items/{item_id}`
- 요청/응답 DTO 작성
- 등록일/유통기한 처리
- 사용자 본인 소유 식재료만 수정/삭제 가능하도록 처리

## 완료 조건
- 등록 성공 시 `201 Created`
- 수정 성공 시 `200 OK`
- 삭제 성공 시 `204 No Content`
- 존재하지 않는 리소스는 `404 NOT_FOUND`
- 타 사용자 리소스 접근은 `403 FORBIDDEN`