### PR TITLE
Feat/issue 19 fridge item list api

### DIFF
--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/fridgeitem/controller/FridgeItemController.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/fridgeitem/controller/FridgeItemController.java
@@ -3,19 +3,25 @@ package com.example.foodaiflatformserver.fridgeitem.controller;
 import com.example.foodaiflatformserver.auth.security.UserPrincipal;
 import com.example.foodaiflatformserver.fridgeitem.dto.FridgeItemResponse;
 import com.example.foodaiflatformserver.fridgeitem.dto.FridgeItemSaveRequest;
+import com.example.foodaiflatformserver.fridgeitem.entity.ItemStatus;
+import com.example.foodaiflatformserver.fridgeitem.entity.StorageLocation;
 import com.example.foodaiflatformserver.fridgeitem.service.FridgeItemService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/fridge-items")
@@ -23,6 +29,16 @@ import org.springframework.web.bind.annotation.RestController;
 public class FridgeItemController {
 
     private final FridgeItemService fridgeItemService;
+
+    @GetMapping
+    public List<FridgeItemResponse> getItems(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(name = "storage_location", required = false) StorageLocation storageLocation,
+            @RequestParam(required = false) ItemStatus status
+    ) {
+        return fridgeItemService.getItems(principal, keyword, storageLocation, status);
+    }
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)

--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/fridgeitem/repository/FridgeItemRepository.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/fridgeitem/repository/FridgeItemRepository.java
@@ -3,5 +3,9 @@ package com.example.foodaiflatformserver.fridgeitem.repository;
 import com.example.foodaiflatformserver.fridgeitem.entity.FridgeItem;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface FridgeItemRepository extends JpaRepository<FridgeItem, Long> {
+
+    List<FridgeItem> findAllByUserIdOrderByExpirationDateAsc(Long userId);
 }

--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/fridgeitem/service/FridgeItemService.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/fridgeitem/service/FridgeItemService.java
@@ -6,6 +6,8 @@ import com.example.foodaiflatformserver.common.exception.NotFoundException;
 import com.example.foodaiflatformserver.fridgeitem.dto.FridgeItemResponse;
 import com.example.foodaiflatformserver.fridgeitem.dto.FridgeItemSaveRequest;
 import com.example.foodaiflatformserver.fridgeitem.entity.FridgeItem;
+import com.example.foodaiflatformserver.fridgeitem.entity.ItemStatus;
+import com.example.foodaiflatformserver.fridgeitem.entity.StorageLocation;
 import com.example.foodaiflatformserver.fridgeitem.repository.FridgeItemRepository;
 import com.example.foodaiflatformserver.user.entity.User;
 import com.example.foodaiflatformserver.user.repository.UserRepository;
@@ -14,6 +16,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.List;
+import java.util.Locale;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +27,23 @@ public class FridgeItemService {
     private final FridgeItemRepository fridgeItemRepository;
     private final UserRepository userRepository;
     private final FridgeItemStatusCalculator statusCalculator;
+
+    public List<FridgeItemResponse> getItems(
+            UserPrincipal principal,
+            String keyword,
+            StorageLocation storageLocation,
+            ItemStatus status
+    ) {
+        String normalizedKeyword = keyword == null ? null : normalize(keyword).toLowerCase(Locale.ROOT);
+
+        return fridgeItemRepository.findAllByUserIdOrderByExpirationDateAsc(principal.id())
+                .stream()
+                .filter(fridgeItem -> matchesKeyword(fridgeItem, normalizedKeyword))
+                .map(fridgeItem -> FridgeItemResponse.from(fridgeItem, statusCalculator))
+                .filter(response -> matchesStorageLocation(response, storageLocation))
+                .filter(response -> matchesStatus(response, status))
+                .toList();
+    }
 
     @Transactional
     public FridgeItemResponse create(UserPrincipal principal, FridgeItemSaveRequest request) {
@@ -78,5 +99,21 @@ public class FridgeItemService {
 
     private String normalize(String value) {
         return value.trim().replaceAll("\\s+", " ");
+    }
+
+    private boolean matchesKeyword(FridgeItem fridgeItem, String keyword) {
+        if (keyword == null || keyword.isBlank()) {
+            return true;
+        }
+
+        return fridgeItem.getName().toLowerCase(Locale.ROOT).contains(keyword);
+    }
+
+    private boolean matchesStorageLocation(FridgeItemResponse response, StorageLocation storageLocation) {
+        return storageLocation == null || response.storageLocation().equals(storageLocation.name());
+    }
+
+    private boolean matchesStatus(FridgeItemResponse response, ItemStatus status) {
+        return status == null || response.status().equals(status.name());
     }
 }

--- a/food-ai-flatform-server/src/test/java/com/example/foodaiflatformserver/fridgeitem/controller/FridgeItemControllerTest.java
+++ b/food-ai-flatform-server/src/test/java/com/example/foodaiflatformserver/fridgeitem/controller/FridgeItemControllerTest.java
@@ -22,6 +22,7 @@ import java.time.LocalDate;
 
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -52,6 +53,92 @@ class FridgeItemControllerTest {
                 .build();
         fridgeItemRepository.deleteAll();
         userRepository.deleteAll();
+    }
+
+    @DisplayName("로그인 사용자의 식재료 전체 목록을 유통기한 임박순으로 조회한다")
+    @Test
+    void getFridgeItemsOrderedByExpirationDate() throws Exception {
+        String accessToken = signupAndLogin("user@example.com");
+        User user = userRepository.findByEmail("user@example.com").orElseThrow();
+        User otherUser = userRepository.save(User.builder()
+                .username("다른사용자")
+                .email("other@example.com")
+                .password("encoded")
+                .build());
+
+        fridgeItemRepository.save(FridgeItem.builder()
+                .user(user)
+                .name("당근")
+                .quantity("1개")
+                .storageLocation(StorageLocation.REFRIGERATED)
+                .registeredDate(LocalDate.of(2026, 5, 1))
+                .expirationDate(LocalDate.now(FridgeItemStatusCalculator.BUSINESS_ZONE).plusDays(7))
+                .build());
+        fridgeItemRepository.save(FridgeItem.builder()
+                .user(user)
+                .name("대파")
+                .quantity("100g")
+                .storageLocation(StorageLocation.REFRIGERATED)
+                .registeredDate(LocalDate.of(2026, 5, 1))
+                .expirationDate(LocalDate.now(FridgeItemStatusCalculator.BUSINESS_ZONE).plusDays(1))
+                .build());
+        fridgeItemRepository.save(FridgeItem.builder()
+                .user(otherUser)
+                .name("외부데이터")
+                .quantity("1개")
+                .storageLocation(StorageLocation.ROOM_TEMP)
+                .registeredDate(LocalDate.of(2026, 5, 1))
+                .expirationDate(LocalDate.now(FridgeItemStatusCalculator.BUSINESS_ZONE).plusDays(0))
+                .build());
+
+        mockMvc.perform(get("/api/v1/fridge-items")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].name").value("대파"))
+                .andExpect(jsonPath("$[0].status").value("WARNING"))
+                .andExpect(jsonPath("$[0].d_day").value(1))
+                .andExpect(jsonPath("$[1].name").value("당근"));
+    }
+
+    @DisplayName("검색어, 보관 위치, 상태 필터를 조합해서 조회할 수 있다")
+    @Test
+    void getFridgeItemsWithCombinedFilters() throws Exception {
+        String accessToken = signupAndLogin("user@example.com");
+        User user = userRepository.findByEmail("user@example.com").orElseThrow();
+
+        fridgeItemRepository.save(FridgeItem.builder()
+                .user(user)
+                .name("대파")
+                .quantity("100g")
+                .storageLocation(StorageLocation.REFRIGERATED)
+                .expirationDate(LocalDate.now(FridgeItemStatusCalculator.BUSINESS_ZONE).plusDays(2))
+                .build());
+        fridgeItemRepository.save(FridgeItem.builder()
+                .user(user)
+                .name("대패삼겹살")
+                .quantity("300g")
+                .storageLocation(StorageLocation.FROZEN)
+                .expirationDate(LocalDate.now(FridgeItemStatusCalculator.BUSINESS_ZONE).plusDays(10))
+                .build());
+        fridgeItemRepository.save(FridgeItem.builder()
+                .user(user)
+                .name("대추")
+                .quantity("10개")
+                .storageLocation(StorageLocation.REFRIGERATED)
+                .expirationDate(LocalDate.now(FridgeItemStatusCalculator.BUSINESS_ZONE).minusDays(1))
+                .build());
+
+        mockMvc.perform(get("/api/v1/fridge-items")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .queryParam("keyword", "대")
+                        .queryParam("storage_location", "REFRIGERATED")
+                        .queryParam("status", "WARNING"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].name").value("대파"))
+                .andExpect(jsonPath("$[0].storage_location").value("REFRIGERATED"))
+                .andExpect(jsonPath("$[0].status").value("WARNING"));
     }
 
     @DisplayName("식재료 등록에 성공하면 201과 생성된 식재료를 반환한다")


### PR DESCRIPTION
## 목적
메인 식재료 목록 조회 API를 구현한다.

## 작업 내용
- `GET /fridge-items`
- 검색 조건 처리
  - `keyword`
  - `storage_location`
  - `status`
- 유통기한 임박순 정렬
- 응답 필드 계산
  - `status`
  - `d_day`
  - `status_text`
- 로그인 사용자 기준 데이터만 조회

## 완료 조건
- 조건 없는 전체 조회가 가능하다
- 검색/필터 조합이 가능하다
- 정렬 기준이 스펙과 일치한다
