### PR TITLE
fix: CORS 허용 설정 추가

### DIFF
--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/auth/security/SecurityConfig.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/auth/security/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.example.foodaiflatformserver.auth.security;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -11,6 +12,12 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.List;
 
 @Configuration
 @EnableMethodSecurity
@@ -21,9 +28,13 @@ public class SecurityConfig {
     private final RestAuthenticationEntryPoint restAuthenticationEntryPoint;
     private final RestAccessDeniedHandler restAccessDeniedHandler;
 
+    @Value("${app.cors.allowed-origins}")
+    private String allowedOrigins;
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
@@ -43,5 +54,21 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(Arrays.stream(allowedOrigins.split(","))
+                .map(String::trim)
+                .filter(origin -> !origin.isEmpty())
+                .toList());
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("Authorization", "Content-Type"));
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }

--- a/food-ai-flatform-server/src/main/resources/application.properties
+++ b/food-ai-flatform-server/src/main/resources/application.properties
@@ -10,3 +10,4 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 
 app.jwt.secret=${APP_JWT_SECRET:food-ai-platform-jwt-secret-key-for-local-development-2026}
 app.jwt.access-token-expiration-seconds=${APP_JWT_ACCESS_TOKEN_EXPIRATION_SECONDS:3600}
+app.cors.allowed-origins=${APP_CORS_ALLOWED_ORIGINS:http://localhost:5500,http://localhost:3000,http://localhost:5173}


### PR DESCRIPTION
## 문제
`SecurityConfig`에 CORS 허용 설정이 없어
브라우저에서 프론트(`food-ai-platform-web`)가
`https://food-ai-platform-api.with-momo.com` 으로 API 요청 시
CORS 정책에 의해 전체 요청이 차단됨
로그인, 식품 조회 등 모든 API가 동작하지 않음

## 수정 내용
- `SecurityConfig.java`에 CORS 허용 설정 추가
- 허용 Origin: 프론트 배포 도메인 및 로컬 개발 환경(`http://localhost:5500` 등)
- 허용 Method: `GET`, `POST`, `PUT`, `DELETE`, `OPTIONS`
- 허용 Header: `Authorization`, `Content-Type`

## 영향 범위
`food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/auth/security/SecurityConfig.java`