### PR TITLE
Feat/issue 20 user preferences api

### DIFF
--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/user/controller/UserPreferenceController.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/user/controller/UserPreferenceController.java
@@ -1,0 +1,35 @@
+package com.example.foodaiflatformserver.user.controller;
+
+import com.example.foodaiflatformserver.auth.security.UserPrincipal;
+import com.example.foodaiflatformserver.user.dto.UserPreferenceResponse;
+import com.example.foodaiflatformserver.user.dto.UserPreferenceSaveRequest;
+import com.example.foodaiflatformserver.user.service.UserPreferenceService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/users/me/preferences")
+@RequiredArgsConstructor
+public class UserPreferenceController {
+
+    private final UserPreferenceService userPreferenceService;
+
+    @PutMapping
+    public UserPreferenceResponse save(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody UserPreferenceSaveRequest request
+    ) {
+        return userPreferenceService.save(principal, request);
+    }
+
+    @GetMapping
+    public UserPreferenceResponse get(@AuthenticationPrincipal UserPrincipal principal) {
+        return userPreferenceService.get(principal);
+    }
+}

--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/user/dto/UserPreferenceResponse.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/user/dto/UserPreferenceResponse.java
@@ -1,0 +1,35 @@
+package com.example.foodaiflatformserver.user.dto;
+
+import com.example.foodaiflatformserver.user.entity.UserPreference;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+public record UserPreferenceResponse(
+        @JsonProperty("user_id")
+        Long userId,
+
+        @JsonProperty("favorite_cuisines")
+        Set<String> favoriteCuisines,
+
+        @JsonProperty("difficulty_preference")
+        String difficultyPreference,
+
+        @JsonProperty("quick_meal_preferred")
+        boolean quickMealPreferred,
+
+        @JsonProperty("updated_at")
+        LocalDateTime updatedAt
+) {
+
+    public static UserPreferenceResponse from(UserPreference preference) {
+        return new UserPreferenceResponse(
+                preference.getUser().getId(),
+                preference.getFavoriteCuisines().stream().map(Enum::name).collect(java.util.stream.Collectors.toCollection(java.util.LinkedHashSet::new)),
+                preference.getDifficultyPreference().name(),
+                preference.isQuickMealPreferred(),
+                preference.getUpdatedAt()
+        );
+    }
+}

--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/user/dto/UserPreferenceSaveRequest.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/user/dto/UserPreferenceSaveRequest.java
@@ -1,0 +1,24 @@
+package com.example.foodaiflatformserver.user.dto;
+
+import com.example.foodaiflatformserver.user.entity.DifficultyPreference;
+import com.example.foodaiflatformserver.user.entity.FavoriteCuisine;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.Set;
+
+public record UserPreferenceSaveRequest(
+        @JsonProperty("favorite_cuisines")
+        @NotEmpty(message = "선호 카테고리는 1개 이상 선택해야 합니다.")
+        Set<FavoriteCuisine> favoriteCuisines,
+
+        @JsonProperty("difficulty_preference")
+        @NotNull(message = "선호 난이도는 필수입니다.")
+        DifficultyPreference difficultyPreference,
+
+        @JsonProperty("quick_meal_preferred")
+        @NotNull(message = "간편식 선호 여부는 필수입니다.")
+        Boolean quickMealPreferred
+) {
+}

--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/user/entity/UserPreference.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/user/entity/UserPreference.java
@@ -83,4 +83,15 @@ public class UserPreference {
     public void assignUser(User user) {
         this.user = user;
     }
+
+    public void update(Set<FavoriteCuisine> favoriteCuisines,
+                       DifficultyPreference difficultyPreference,
+                       boolean quickMealPreferred) {
+        this.favoriteCuisines.clear();
+        if (favoriteCuisines != null) {
+            this.favoriteCuisines.addAll(favoriteCuisines);
+        }
+        this.difficultyPreference = difficultyPreference;
+        this.quickMealPreferred = quickMealPreferred;
+    }
 }

--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/user/repository/UserPreferenceRepository.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/user/repository/UserPreferenceRepository.java
@@ -1,0 +1,11 @@
+package com.example.foodaiflatformserver.user.repository;
+
+import com.example.foodaiflatformserver.user.entity.UserPreference;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserPreferenceRepository extends JpaRepository<UserPreference, Long> {
+
+    Optional<UserPreference> findByUserId(Long userId);
+}

--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/user/repository/UserRepository.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/user/repository/UserRepository.java
@@ -1,8 +1,11 @@
 package com.example.foodaiflatformserver.user.repository;
 
 import com.example.foodaiflatformserver.user.entity.User;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
-
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -10,4 +13,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
 
     Optional<User> findByEmail(String email);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select u from User u where u.id = :userId")
+    Optional<User> findByIdForUpdate(@Param("userId") Long userId);
 }

--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/user/service/UserPreferenceService.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/user/service/UserPreferenceService.java
@@ -1,0 +1,57 @@
+package com.example.foodaiflatformserver.user.service;
+
+import com.example.foodaiflatformserver.auth.security.UserPrincipal;
+import com.example.foodaiflatformserver.common.exception.NotFoundException;
+import com.example.foodaiflatformserver.user.dto.UserPreferenceResponse;
+import com.example.foodaiflatformserver.user.dto.UserPreferenceSaveRequest;
+import com.example.foodaiflatformserver.user.entity.User;
+import com.example.foodaiflatformserver.user.entity.UserPreference;
+import com.example.foodaiflatformserver.user.repository.UserPreferenceRepository;
+import com.example.foodaiflatformserver.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserPreferenceService {
+
+    private final UserRepository userRepository;
+    private final UserPreferenceRepository userPreferenceRepository;
+
+    @Transactional
+    public UserPreferenceResponse save(UserPrincipal principal, UserPreferenceSaveRequest request) {
+        User user = userRepository.findById(principal.id())
+                .orElseThrow(() -> new NotFoundException("사용자를 찾을 수 없습니다."));
+
+        UserPreference preference = userPreferenceRepository.findByUserId(user.getId())
+                .map(existing -> {
+                    existing.update(
+                            request.favoriteCuisines(),
+                            request.difficultyPreference(),
+                            request.quickMealPreferred()
+                    );
+                    return existing;
+                })
+                .orElseGet(() -> {
+                    UserPreference created = UserPreference.builder()
+                            .favoriteCuisines(request.favoriteCuisines())
+                            .difficultyPreference(request.difficultyPreference())
+                            .quickMealPreferred(request.quickMealPreferred())
+                            .build();
+                    user.assignPreference(created);
+                    return created;
+                });
+
+        UserPreference savedPreference = userPreferenceRepository.save(preference);
+        return UserPreferenceResponse.from(savedPreference);
+    }
+
+    public UserPreferenceResponse get(UserPrincipal principal) {
+        UserPreference preference = userPreferenceRepository.findByUserId(principal.id())
+                .orElseThrow(() -> new NotFoundException("사용자 취향 정보를 찾을 수 없습니다."));
+
+        return UserPreferenceResponse.from(preference);
+    }
+}

--- a/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/user/service/UserPreferenceService.java
+++ b/food-ai-flatform-server/src/main/java/com/example/foodaiflatformserver/user/service/UserPreferenceService.java
@@ -22,9 +22,10 @@ public class UserPreferenceService {
 
     @Transactional
     public UserPreferenceResponse save(UserPrincipal principal, UserPreferenceSaveRequest request) {
-        User user = userRepository.findById(principal.id())
+        User user = userRepository.findByIdForUpdate(principal.id())
                 .orElseThrow(() -> new NotFoundException("사용자를 찾을 수 없습니다."));
 
+        // Lock the owning user row so first-time preference creation is serialized per user.
         UserPreference preference = userPreferenceRepository.findByUserId(user.getId())
                 .map(existing -> {
                     existing.update(

--- a/food-ai-flatform-server/src/test/java/com/example/foodaiflatformserver/user/controller/UserPreferenceControllerTest.java
+++ b/food-ai-flatform-server/src/test/java/com/example/foodaiflatformserver/user/controller/UserPreferenceControllerTest.java
@@ -1,0 +1,170 @@
+package com.example.foodaiflatformserver.user.controller;
+
+import com.example.foodaiflatformserver.user.entity.User;
+import com.example.foodaiflatformserver.user.repository.UserPreferenceRepository;
+import com.example.foodaiflatformserver.user.repository.UserRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
+
+@SpringBootTest
+class UserPreferenceControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserPreferenceRepository userPreferenceRepository;
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = webAppContextSetup(webApplicationContext)
+                .apply(springSecurity())
+                .build();
+        userPreferenceRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @DisplayName("사용자 취향을 저장한 뒤 즉시 조회할 수 있다")
+    @Test
+    void saveAndGetPreferences() throws Exception {
+        String accessToken = signupAndLogin("user@example.com");
+
+        mockMvc.perform(put("/api/v1/users/me/preferences")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "favorite_cuisines": ["KOREAN", "JAPANESE"],
+                                  "difficulty_preference": "EASY",
+                                  "quick_meal_preferred": true
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.user_id").isNumber())
+                .andExpect(jsonPath("$.favorite_cuisines[0]").value("KOREAN"))
+                .andExpect(jsonPath("$.favorite_cuisines[1]").value("JAPANESE"))
+                .andExpect(jsonPath("$.difficulty_preference").value("EASY"))
+                .andExpect(jsonPath("$.quick_meal_preferred").value(true));
+
+        mockMvc.perform(get("/api/v1/users/me/preferences")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.favorite_cuisines[0]").value("KOREAN"))
+                .andExpect(jsonPath("$.favorite_cuisines[1]").value("JAPANESE"))
+                .andExpect(jsonPath("$.difficulty_preference").value("EASY"))
+                .andExpect(jsonPath("$.quick_meal_preferred").value(true));
+    }
+
+    @DisplayName("동일 사용자가 다시 저장하면 기존 취향이 갱신된다")
+    @Test
+    void upsertsPreferences() throws Exception {
+        String accessToken = signupAndLogin("user@example.com");
+
+        mockMvc.perform(put("/api/v1/users/me/preferences")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "favorite_cuisines": ["KOREAN"],
+                                  "difficulty_preference": "EASY",
+                                  "quick_meal_preferred": true
+                                }
+                                """))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(put("/api/v1/users/me/preferences")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "favorite_cuisines": ["WESTERN", "CHINESE"],
+                                  "difficulty_preference": "HARD",
+                                  "quick_meal_preferred": false
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.favorite_cuisines[0]").value("WESTERN"))
+                .andExpect(jsonPath("$.favorite_cuisines[1]").value("CHINESE"))
+                .andExpect(jsonPath("$.difficulty_preference").value("HARD"))
+                .andExpect(jsonPath("$.quick_meal_preferred").value(false));
+
+        mockMvc.perform(get("/api/v1/users/me/preferences")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.favorite_cuisines[0]").value("WESTERN"))
+                .andExpect(jsonPath("$.favorite_cuisines[1]").value("CHINESE"))
+                .andExpect(jsonPath("$.difficulty_preference").value("HARD"))
+                .andExpect(jsonPath("$.quick_meal_preferred").value(false));
+    }
+
+    @DisplayName("잘못된 enum 값은 400 INVALID_REQUEST를 반환한다")
+    @Test
+    void rejectsInvalidEnumValues() throws Exception {
+        String accessToken = signupAndLogin("user@example.com");
+
+        mockMvc.perform(put("/api/v1/users/me/preferences")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "favorite_cuisines": ["KOREAN", "MEXICAN"],
+                                  "difficulty_preference": "VERY_EASY",
+                                  "quick_meal_preferred": true
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_REQUEST"));
+    }
+
+    private String signupAndLogin(String email) throws Exception {
+        mockMvc.perform(post("/api/v1/auth/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                        {
+                          "username": "홍길동",
+                          "email": "%s",
+                          "password": "Password123!"
+                        }
+                        """.formatted(email)));
+
+        String loginResponse = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "email": "%s",
+                                  "password": "Password123!"
+                                }
+                                """.formatted(email)))
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        JsonNode jsonNode = objectMapper.readTree(loginResponse);
+        return jsonNode.get("access_token").asText();
+    }
+}


### PR DESCRIPTION
## 목적
온보딩 취향 정보를 저장하고 조회하는 API를 구현한다.

## 작업 내용
- `PUT /users/me/preferences`
- `GET /users/me/preferences`
- 선호 카테고리, 난이도, 간편식 선호 여부 저장
- 동일 사용자 재저장 시 upsert 처리
- enum validation 적용

## 완료 조건
- 저장 후 즉시 조회 가능하다
- 재저장 시 기존 값이 갱신된다
- 잘못된 enum 값은 validation 에러를 반환한다