### PR TITLE
[BE] 사용자 취향 저장/조회 API 구현

### DIFF
--- a/food-ai-platform-server/build.gradle
+++ b/food-ai-platform-server/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+    implementation 'org.springframework.security:spring-security-crypto'
     runtimeOnly 'com.mysql:mysql-connector-j'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/config/WebMvcAuthConfig.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/config/WebMvcAuthConfig.java
@@ -1,0 +1,23 @@
+package com.example.foodaiflatformserver.auth.config;
+
+import com.example.foodaiflatformserver.auth.security.AuthInterceptor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcAuthConfig implements WebMvcConfigurer {
+
+    private final AuthInterceptor authInterceptor;
+
+    public WebMvcAuthConfig(AuthInterceptor authInterceptor) {
+        this.authInterceptor = authInterceptor;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authInterceptor)
+                .addPathPatterns("/**")
+                .excludePathPatterns("/auth/signup", "/auth/login", "/error");
+    }
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/config/WebMvcAuthConfig.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/config/WebMvcAuthConfig.java
@@ -1,17 +1,28 @@
 package com.example.foodaiflatformserver.auth.config;
 
 import com.example.foodaiflatformserver.auth.security.AuthInterceptor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.Arrays;
 
 @Configuration
 public class WebMvcAuthConfig implements WebMvcConfigurer {
 
     private final AuthInterceptor authInterceptor;
+    private final String[] allowedOrigins;
+    private final String[] allowedOriginPatterns;
 
-    public WebMvcAuthConfig(AuthInterceptor authInterceptor) {
+    public WebMvcAuthConfig(AuthInterceptor authInterceptor,
+                            @Value("${app.cors.allowed-origins}") String allowedOrigins,
+                            @Value("${app.cors.allowed-origin-patterns:}") String allowedOriginPatterns) {
         this.authInterceptor = authInterceptor;
+        this.allowedOrigins = splitCsv(allowedOrigins);
+        this.allowedOriginPatterns = splitCsv(allowedOriginPatterns);
     }
 
     @Override
@@ -19,5 +30,23 @@ public class WebMvcAuthConfig implements WebMvcConfigurer {
         registry.addInterceptor(authInterceptor)
                 .addPathPatterns("/**")
                 .excludePathPatterns("/auth/signup", "/auth/login", "/error");
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins(allowedOrigins)
+                .allowedOriginPatterns(allowedOriginPatterns)
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders(HttpHeaders.AUTHORIZATION, HttpHeaders.CONTENT_TYPE)
+                .allowCredentials(true)
+                .maxAge(3600);
+    }
+
+    private String[] splitCsv(String value) {
+        return Arrays.stream(value.split(","))
+                .map(String::trim)
+                .filter(item -> !item.isEmpty())
+                .toArray(String[]::new);
     }
 }

--- a/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/controller/AuthController.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/controller/AuthController.java
@@ -1,0 +1,43 @@
+package com.example.foodaiflatformserver.auth.controller;
+
+import com.example.foodaiflatformserver.auth.dto.AuthLoginRequest;
+import com.example.foodaiflatformserver.auth.dto.AuthLoginResponse;
+import com.example.foodaiflatformserver.auth.dto.AuthSignupRequest;
+import com.example.foodaiflatformserver.auth.dto.AuthSignupResponse;
+import com.example.foodaiflatformserver.auth.dto.AuthUserResponse;
+import com.example.foodaiflatformserver.auth.service.AuthService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/signup")
+    @ResponseStatus(HttpStatus.CREATED)
+    public AuthSignupResponse signup(@Valid @RequestBody AuthSignupRequest request) {
+        return authService.signup(request);
+    }
+
+    @PostMapping("/login")
+    public AuthLoginResponse login(@Valid @RequestBody AuthLoginRequest request) {
+        return authService.login(request);
+    }
+
+    @GetMapping("/me")
+    public AuthUserResponse me() {
+        return authService.me();
+    }
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/dto/AuthLoginRequest.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/dto/AuthLoginRequest.java
@@ -1,0 +1,17 @@
+package com.example.foodaiflatformserver.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record AuthLoginRequest(
+        @JsonProperty("email")
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        String email,
+
+        @JsonProperty("password")
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        String password
+) {
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/dto/AuthLoginResponse.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/dto/AuthLoginResponse.java
@@ -1,0 +1,18 @@
+package com.example.foodaiflatformserver.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record AuthLoginResponse(
+        @JsonProperty("message")
+        String message,
+
+        @JsonProperty("access_token")
+        String accessToken,
+
+        @JsonProperty("token_type")
+        String tokenType,
+
+        @JsonProperty("user")
+        AuthUserResponse user
+) {
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/dto/AuthSignupRequest.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/dto/AuthSignupRequest.java
@@ -1,0 +1,23 @@
+package com.example.foodaiflatformserver.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record AuthSignupRequest(
+        @JsonProperty("username")
+        @NotBlank(message = "이름은 필수입니다.")
+        String username,
+
+        @JsonProperty("email")
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        String email,
+
+        @JsonProperty("password")
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
+        String password
+) {
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/dto/AuthSignupRequest.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/dto/AuthSignupRequest.java
@@ -8,11 +8,13 @@ import jakarta.validation.constraints.Size;
 public record AuthSignupRequest(
         @JsonProperty("username")
         @NotBlank(message = "이름은 필수입니다.")
+        @Size(max = 100, message = "이름은 100자 이하여야 합니다.")
         String username,
 
         @JsonProperty("email")
         @NotBlank(message = "이메일은 필수입니다.")
         @Email(message = "이메일 형식이 올바르지 않습니다.")
+        @Size(max = 255, message = "이메일은 255자 이하여야 합니다.")
         String email,
 
         @JsonProperty("password")

--- a/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/dto/AuthSignupResponse.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/dto/AuthSignupResponse.java
@@ -1,0 +1,12 @@
+package com.example.foodaiflatformserver.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record AuthSignupResponse(
+        @JsonProperty("message")
+        String message,
+
+        @JsonProperty("user")
+        AuthUserResponse user
+) {
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/dto/AuthUserResponse.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/dto/AuthUserResponse.java
@@ -1,0 +1,15 @@
+package com.example.foodaiflatformserver.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record AuthUserResponse(
+        @JsonProperty("user_id")
+        Long userId,
+
+        @JsonProperty("username")
+        String username,
+
+        @JsonProperty("email")
+        String email
+) {
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/dto/AuthenticatedUser.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/dto/AuthenticatedUser.java
@@ -1,0 +1,7 @@
+package com.example.foodaiflatformserver.auth.dto;
+
+public record AuthenticatedUser(
+        Long userId,
+        String email
+) {
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/entity/UserAccount.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/entity/UserAccount.java
@@ -1,0 +1,51 @@
+package com.example.foodaiflatformserver.auth.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "users")
+public class UserAccount {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 100)
+    private String username;
+
+    @Column(nullable = false, unique = true, length = 255)
+    private String email;
+
+    @Column(name = "password_hash", nullable = false, length = 255)
+    private String passwordHash;
+
+    protected UserAccount() {
+    }
+
+    public UserAccount(String username, String email, String passwordHash) {
+        this.username = username;
+        this.email = email;
+        this.passwordHash = passwordHash;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getPasswordHash() {
+        return passwordHash;
+    }
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/exception/AuthenticationFailedException.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/exception/AuthenticationFailedException.java
@@ -1,0 +1,10 @@
+package com.example.foodaiflatformserver.auth.exception;
+
+import com.example.foodaiflatformserver.common.exception.UnauthorizedException;
+
+public class AuthenticationFailedException extends UnauthorizedException {
+
+    public AuthenticationFailedException() {
+        super("이메일 또는 비밀번호가 일치하지 않습니다.");
+    }
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/exception/DuplicateEmailException.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/exception/DuplicateEmailException.java
@@ -1,0 +1,10 @@
+package com.example.foodaiflatformserver.auth.exception;
+
+import com.example.foodaiflatformserver.common.exception.ConflictException;
+
+public class DuplicateEmailException extends ConflictException {
+
+    public DuplicateEmailException(String email) {
+        super("이미 가입된 이메일입니다. email=" + email);
+    }
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/exception/InvalidTokenException.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/exception/InvalidTokenException.java
@@ -1,0 +1,10 @@
+package com.example.foodaiflatformserver.auth.exception;
+
+import com.example.foodaiflatformserver.common.exception.UnauthorizedException;
+
+public class InvalidTokenException extends UnauthorizedException {
+
+    public InvalidTokenException(String message) {
+        super(message);
+    }
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/exception/UserAccountNotFoundException.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/exception/UserAccountNotFoundException.java
@@ -1,0 +1,10 @@
+package com.example.foodaiflatformserver.auth.exception;
+
+import com.example.foodaiflatformserver.common.exception.NotFoundException;
+
+public class UserAccountNotFoundException extends NotFoundException {
+
+    public UserAccountNotFoundException(Long userId) {
+        super("사용자를 찾을 수 없습니다. user_id=" + userId);
+    }
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/repository/UserAccountRepository.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/repository/UserAccountRepository.java
@@ -1,0 +1,13 @@
+package com.example.foodaiflatformserver.auth.repository;
+
+import com.example.foodaiflatformserver.auth.entity.UserAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserAccountRepository extends JpaRepository<UserAccount, Long> {
+
+    boolean existsByEmail(String email);
+
+    Optional<UserAccount> findByEmail(String email);
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/security/AuthInterceptor.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/security/AuthInterceptor.java
@@ -1,0 +1,34 @@
+package com.example.foodaiflatformserver.auth.security;
+
+import com.example.foodaiflatformserver.auth.dto.AuthenticatedUser;
+import com.example.foodaiflatformserver.common.exception.UnauthorizedException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+public class AuthInterceptor implements HandlerInterceptor {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public AuthInterceptor(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        String authorization = request.getHeader("Authorization");
+        if (authorization == null || !authorization.startsWith(BEARER_PREFIX)) {
+            throw new UnauthorizedException("인증이 필요합니다.");
+        }
+
+        String token = authorization.substring(BEARER_PREFIX.length());
+        AuthenticatedUser authenticatedUser = jwtTokenProvider.parse(token);
+        request.setAttribute(AuthenticationContext.CURRENT_USER_ID, authenticatedUser.userId());
+        request.setAttribute(AuthenticationContext.CURRENT_USER_EMAIL, authenticatedUser.email());
+        return true;
+    }
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/security/AuthInterceptor.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/security/AuthInterceptor.java
@@ -5,6 +5,7 @@ import com.example.foodaiflatformserver.common.exception.UnauthorizedException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.stereotype.Component;
+import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 @Component
@@ -20,6 +21,10 @@ public class AuthInterceptor implements HandlerInterceptor {
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        if (CorsUtils.isPreFlightRequest(request)) {
+            return true;
+        }
+
         String authorization = request.getHeader("Authorization");
         if (authorization == null || !authorization.startsWith(BEARER_PREFIX)) {
             throw new UnauthorizedException("인증이 필요합니다.");

--- a/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/security/AuthenticationContext.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/security/AuthenticationContext.java
@@ -1,0 +1,10 @@
+package com.example.foodaiflatformserver.auth.security;
+
+public final class AuthenticationContext {
+
+    public static final String CURRENT_USER_ID = "currentUserId";
+    public static final String CURRENT_USER_EMAIL = "currentUserEmail";
+
+    private AuthenticationContext() {
+    }
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/security/JwtTokenProvider.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/security/JwtTokenProvider.java
@@ -1,0 +1,95 @@
+package com.example.foodaiflatformserver.auth.security;
+
+import com.example.foodaiflatformserver.auth.dto.AuthenticatedUser;
+import com.example.foodaiflatformserver.auth.exception.InvalidTokenException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Component
+public class JwtTokenProvider {
+
+    private static final Base64.Encoder URL_ENCODER = Base64.getUrlEncoder().withoutPadding();
+    private static final Base64.Decoder URL_DECODER = Base64.getUrlDecoder();
+    private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {
+    };
+
+    private final ObjectMapper objectMapper;
+    private final byte[] secretKey;
+    private final long expirationSeconds;
+
+    public JwtTokenProvider(ObjectMapper objectMapper,
+                            @Value("${app.jwt.secret:food-ai-platform-secret-key-change-me}") String secret,
+                            @Value("${app.jwt.expiration-seconds:86400}") long expirationSeconds) {
+        this.objectMapper = objectMapper;
+        this.secretKey = secret.getBytes(StandardCharsets.UTF_8);
+        this.expirationSeconds = expirationSeconds;
+    }
+
+    public String createToken(Long userId, String email) {
+        try {
+            long issuedAt = Instant.now().getEpochSecond();
+            long expiresAt = issuedAt + expirationSeconds;
+
+            String header = encodeJson(Map.of("alg", "HS256", "typ", "JWT"));
+            Map<String, Object> payloadMap = new LinkedHashMap<>();
+            payloadMap.put("sub", String.valueOf(userId));
+            payloadMap.put("email", email);
+            payloadMap.put("iat", issuedAt);
+            payloadMap.put("exp", expiresAt);
+            String payload = encodeJson(payloadMap);
+
+            String signature = sign(header + "." + payload);
+            return header + "." + payload + "." + signature;
+        } catch (Exception exception) {
+            throw new IllegalStateException("JWT 토큰 생성에 실패했습니다.", exception);
+        }
+    }
+
+    public AuthenticatedUser parse(String token) {
+        try {
+            String[] parts = token.split("\\.");
+            if (parts.length != 3) {
+                throw new InvalidTokenException("토큰 형식이 올바르지 않습니다.");
+            }
+
+            String expectedSignature = sign(parts[0] + "." + parts[1]);
+            if (!expectedSignature.equals(parts[2])) {
+                throw new InvalidTokenException("토큰 서명이 올바르지 않습니다.");
+            }
+
+            Map<String, Object> payload = objectMapper.readValue(URL_DECODER.decode(parts[1]), MAP_TYPE);
+            long expiresAt = ((Number) payload.get("exp")).longValue();
+            if (Instant.now().getEpochSecond() > expiresAt) {
+                throw new InvalidTokenException("토큰이 만료되었습니다.");
+            }
+
+            Long userId = Long.valueOf(String.valueOf(payload.get("sub")));
+            String email = String.valueOf(payload.get("email"));
+            return new AuthenticatedUser(userId, email);
+        } catch (InvalidTokenException exception) {
+            throw exception;
+        } catch (Exception exception) {
+            throw new InvalidTokenException("토큰이 올바르지 않습니다.");
+        }
+    }
+
+    private String encodeJson(Map<String, Object> payload) throws Exception {
+        return URL_ENCODER.encodeToString(objectMapper.writeValueAsBytes(payload));
+    }
+
+    private String sign(String value) throws Exception {
+        Mac mac = Mac.getInstance("HmacSHA256");
+        mac.init(new SecretKeySpec(secretKey, "HmacSHA256"));
+        return URL_ENCODER.encodeToString(mac.doFinal(value.getBytes(StandardCharsets.UTF_8)));
+    }
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/service/AuthService.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/service/AuthService.java
@@ -11,7 +11,9 @@ import com.example.foodaiflatformserver.auth.exception.DuplicateEmailException;
 import com.example.foodaiflatformserver.auth.exception.UserAccountNotFoundException;
 import com.example.foodaiflatformserver.auth.repository.UserAccountRepository;
 import com.example.foodaiflatformserver.auth.security.JwtTokenProvider;
+import com.example.foodaiflatformserver.common.support.KeyedLockExecutor;
 import com.example.foodaiflatformserver.user.service.CurrentUserProvider;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,30 +24,39 @@ public class AuthService {
     private final UserAccountRepository userAccountRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final CurrentUserProvider currentUserProvider;
+    private final KeyedLockExecutor keyedLockExecutor;
     private final BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 
     public AuthService(UserAccountRepository userAccountRepository,
                        JwtTokenProvider jwtTokenProvider,
-                       CurrentUserProvider currentUserProvider) {
+                       CurrentUserProvider currentUserProvider,
+                       KeyedLockExecutor keyedLockExecutor) {
         this.userAccountRepository = userAccountRepository;
         this.jwtTokenProvider = jwtTokenProvider;
         this.currentUserProvider = currentUserProvider;
+        this.keyedLockExecutor = keyedLockExecutor;
     }
 
     @Transactional
     public AuthSignupResponse signup(AuthSignupRequest request) {
-        if (userAccountRepository.existsByEmail(request.email())) {
-            throw new DuplicateEmailException(request.email());
-        }
+        return keyedLockExecutor.execute("signup:" + request.email(), () -> {
+            if (userAccountRepository.existsByEmail(request.email())) {
+                throw new DuplicateEmailException(request.email());
+            }
 
-        UserAccount userAccount = new UserAccount(
-                request.username(),
-                request.email(),
-                passwordEncoder.encode(request.password())
-        );
-        UserAccount saved = userAccountRepository.save(userAccount);
+            UserAccount userAccount = new UserAccount(
+                    request.username(),
+                    request.email(),
+                    passwordEncoder.encode(request.password())
+            );
 
-        return new AuthSignupResponse("회원가입이 완료되었습니다.", toUserResponse(saved));
+            try {
+                UserAccount saved = userAccountRepository.saveAndFlush(userAccount);
+                return new AuthSignupResponse("회원가입이 완료되었습니다.", toUserResponse(saved));
+            } catch (DataIntegrityViolationException exception) {
+                throw new DuplicateEmailException(request.email());
+            }
+        });
     }
 
     @Transactional(readOnly = true)

--- a/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/service/AuthService.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/auth/service/AuthService.java
@@ -1,0 +1,72 @@
+package com.example.foodaiflatformserver.auth.service;
+
+import com.example.foodaiflatformserver.auth.dto.AuthLoginRequest;
+import com.example.foodaiflatformserver.auth.dto.AuthLoginResponse;
+import com.example.foodaiflatformserver.auth.dto.AuthSignupRequest;
+import com.example.foodaiflatformserver.auth.dto.AuthSignupResponse;
+import com.example.foodaiflatformserver.auth.dto.AuthUserResponse;
+import com.example.foodaiflatformserver.auth.entity.UserAccount;
+import com.example.foodaiflatformserver.auth.exception.AuthenticationFailedException;
+import com.example.foodaiflatformserver.auth.exception.DuplicateEmailException;
+import com.example.foodaiflatformserver.auth.exception.UserAccountNotFoundException;
+import com.example.foodaiflatformserver.auth.repository.UserAccountRepository;
+import com.example.foodaiflatformserver.auth.security.JwtTokenProvider;
+import com.example.foodaiflatformserver.user.service.CurrentUserProvider;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class AuthService {
+
+    private final UserAccountRepository userAccountRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final CurrentUserProvider currentUserProvider;
+    private final BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+    public AuthService(UserAccountRepository userAccountRepository,
+                       JwtTokenProvider jwtTokenProvider,
+                       CurrentUserProvider currentUserProvider) {
+        this.userAccountRepository = userAccountRepository;
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.currentUserProvider = currentUserProvider;
+    }
+
+    @Transactional
+    public AuthSignupResponse signup(AuthSignupRequest request) {
+        if (userAccountRepository.existsByEmail(request.email())) {
+            throw new DuplicateEmailException(request.email());
+        }
+
+        UserAccount userAccount = new UserAccount(
+                request.username(),
+                request.email(),
+                passwordEncoder.encode(request.password())
+        );
+        UserAccount saved = userAccountRepository.save(userAccount);
+
+        return new AuthSignupResponse("회원가입이 완료되었습니다.", toUserResponse(saved));
+    }
+
+    @Transactional(readOnly = true)
+    public AuthLoginResponse login(AuthLoginRequest request) {
+        UserAccount userAccount = userAccountRepository.findByEmail(request.email())
+                .filter(user -> passwordEncoder.matches(request.password(), user.getPasswordHash()))
+                .orElseThrow(AuthenticationFailedException::new);
+
+        String token = jwtTokenProvider.createToken(userAccount.getId(), userAccount.getEmail());
+        return new AuthLoginResponse("로그인 성공", token, "Bearer", toUserResponse(userAccount));
+    }
+
+    @Transactional(readOnly = true)
+    public AuthUserResponse me() {
+        Long userId = currentUserProvider.getCurrentUserId();
+        UserAccount userAccount = userAccountRepository.findById(userId)
+                .orElseThrow(() -> new UserAccountNotFoundException(userId));
+        return toUserResponse(userAccount);
+    }
+
+    private AuthUserResponse toUserResponse(UserAccount userAccount) {
+        return new AuthUserResponse(userAccount.getId(), userAccount.getUsername(), userAccount.getEmail());
+    }
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/common/config/JacksonConfig.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/common/config/JacksonConfig.java
@@ -1,0 +1,14 @@
+package com.example.foodaiflatformserver.common.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper().findAndRegisterModules();
+    }
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/common/support/KeyedLockExecutor.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/common/support/KeyedLockExecutor.java
@@ -1,0 +1,26 @@
+package com.example.foodaiflatformserver.common.support;
+
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
+
+@Component
+public class KeyedLockExecutor {
+
+    private final ConcurrentHashMap<String, ReentrantLock> locks = new ConcurrentHashMap<>();
+
+    public <T> T execute(String key, Supplier<T> action) {
+        ReentrantLock lock = locks.computeIfAbsent(key, ignored -> new ReentrantLock());
+        lock.lock();
+        try {
+            return action.get();
+        } finally {
+            lock.unlock();
+            if (!lock.isLocked() && !lock.hasQueuedThreads()) {
+                locks.remove(key, lock);
+            }
+        }
+    }
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/user/controller/UserPreferenceController.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/user/controller/UserPreferenceController.java
@@ -1,0 +1,32 @@
+package com.example.foodaiflatformserver.user.controller;
+
+import com.example.foodaiflatformserver.user.dto.UserPreferenceResponse;
+import com.example.foodaiflatformserver.user.dto.UserPreferenceUpsertRequest;
+import com.example.foodaiflatformserver.user.service.UserPreferenceService;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/users/me/preferences")
+public class UserPreferenceController {
+
+    private final UserPreferenceService userPreferenceService;
+
+    public UserPreferenceController(UserPreferenceService userPreferenceService) {
+        this.userPreferenceService = userPreferenceService;
+    }
+
+    @PutMapping
+    public UserPreferenceResponse upsert(@Valid @RequestBody UserPreferenceUpsertRequest request) {
+        return userPreferenceService.upsert(request);
+    }
+
+    @GetMapping
+    public UserPreferenceResponse getCurrentUserPreference() {
+        return userPreferenceService.getCurrentUserPreference();
+    }
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/user/dto/UserPreferenceResponse.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/user/dto/UserPreferenceResponse.java
@@ -1,0 +1,25 @@
+package com.example.foodaiflatformserver.user.dto;
+
+import com.example.foodaiflatformserver.user.entity.DifficultyPreference;
+import com.example.foodaiflatformserver.user.entity.FavoriteCuisine;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record UserPreferenceResponse(
+        @JsonProperty("user_id")
+        Long userId,
+        @JsonProperty("favorite_cuisines")
+        List<FavoriteCuisine> favoriteCuisines,
+        @JsonProperty("difficulty_preference")
+        DifficultyPreference difficultyPreference,
+        @JsonProperty("quick_meal_preferred")
+        boolean quickMealPreferred,
+        @JsonProperty("updated_at")
+        LocalDateTime updatedAt
+) {
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/user/dto/UserPreferenceUpsertRequest.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/user/dto/UserPreferenceUpsertRequest.java
@@ -1,0 +1,31 @@
+package com.example.foodaiflatformserver.user.dto;
+
+import com.example.foodaiflatformserver.user.entity.DifficultyPreference;
+import com.example.foodaiflatformserver.user.entity.FavoriteCuisine;
+import com.example.foodaiflatformserver.user.validation.EnumValue;
+import com.example.foodaiflatformserver.user.validation.EnumValues;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record UserPreferenceUpsertRequest(
+        @JsonProperty("favorite_cuisines")
+        @NotEmpty(message = "선호 카테고리는 최소 1개 이상 선택해야 합니다.")
+        @EnumValues(enumClass = FavoriteCuisine.class, message = "선호 카테고리 값이 올바르지 않습니다.")
+        List<String> favoriteCuisines,
+
+        @JsonProperty("difficulty_preference")
+        @NotNull(message = "난이도 선호는 필수입니다.")
+        @EnumValue(enumClass = DifficultyPreference.class, message = "난이도 선호 값이 올바르지 않습니다.")
+        String difficultyPreference,
+
+        @JsonProperty("quick_meal_preferred")
+        @NotNull(message = "간편식 선호 여부는 필수입니다.")
+        Boolean quickMealPreferred
+) {
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/user/entity/UserPreference.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/user/entity/UserPreference.java
@@ -1,0 +1,93 @@
+package com.example.foodaiflatformserver.user.entity;
+
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OrderColumn;
+import jakarta.persistence.Table;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "user_preferences")
+public class UserPreference {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false, unique = true)
+    private Long userId;
+
+    @ElementCollection(targetClass = FavoriteCuisine.class)
+    @CollectionTable(name = "user_preference_favorite_cuisines", joinColumns = @JoinColumn(name = "user_preference_id"))
+    @Enumerated(EnumType.STRING)
+    @Column(name = "favorite_cuisine", nullable = false)
+    @OrderColumn(name = "sort_order")
+    private List<FavoriteCuisine> favoriteCuisines = new ArrayList<>();
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "difficulty_preference", nullable = false)
+    private DifficultyPreference difficultyPreference;
+
+    @Column(name = "quick_meal_preferred", nullable = false)
+    private boolean quickMealPreferred;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    protected UserPreference() {
+    }
+
+    public UserPreference(Long userId,
+                          List<FavoriteCuisine> favoriteCuisines,
+                          DifficultyPreference difficultyPreference,
+                          boolean quickMealPreferred,
+                          LocalDateTime updatedAt) {
+        this.userId = userId;
+        this.favoriteCuisines = new ArrayList<>(favoriteCuisines);
+        this.difficultyPreference = difficultyPreference;
+        this.quickMealPreferred = quickMealPreferred;
+        this.updatedAt = updatedAt;
+    }
+
+    public void update(List<FavoriteCuisine> favoriteCuisines,
+                       DifficultyPreference difficultyPreference,
+                       boolean quickMealPreferred,
+                       LocalDateTime updatedAt) {
+        this.favoriteCuisines.clear();
+        this.favoriteCuisines.addAll(favoriteCuisines);
+        this.difficultyPreference = difficultyPreference;
+        this.quickMealPreferred = quickMealPreferred;
+        this.updatedAt = updatedAt;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public List<FavoriteCuisine> getFavoriteCuisines() {
+        return List.copyOf(favoriteCuisines);
+    }
+
+    public DifficultyPreference getDifficultyPreference() {
+        return difficultyPreference;
+    }
+
+    public boolean isQuickMealPreferred() {
+        return quickMealPreferred;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/user/exception/UserPreferenceNotFoundException.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/user/exception/UserPreferenceNotFoundException.java
@@ -1,0 +1,10 @@
+package com.example.foodaiflatformserver.user.exception;
+
+import com.example.foodaiflatformserver.common.exception.NotFoundException;
+
+public class UserPreferenceNotFoundException extends NotFoundException {
+
+    public UserPreferenceNotFoundException(Long userId) {
+        super("사용자 취향 정보를 찾을 수 없습니다. user_id=" + userId);
+    }
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/user/repository/UserPreferenceRepository.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/user/repository/UserPreferenceRepository.java
@@ -1,0 +1,11 @@
+package com.example.foodaiflatformserver.user.repository;
+
+import com.example.foodaiflatformserver.user.entity.UserPreference;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserPreferenceRepository extends JpaRepository<UserPreference, Long> {
+
+    Optional<UserPreference> findByUserId(Long userId);
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/user/service/CurrentUserProvider.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/user/service/CurrentUserProvider.java
@@ -1,0 +1,6 @@
+package com.example.foodaiflatformserver.user.service;
+
+public interface CurrentUserProvider {
+
+    Long getCurrentUserId();
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/user/service/RequestCurrentUserProvider.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/user/service/RequestCurrentUserProvider.java
@@ -1,0 +1,28 @@
+package com.example.foodaiflatformserver.user.service;
+
+import com.example.foodaiflatformserver.auth.security.AuthenticationContext;
+import com.example.foodaiflatformserver.common.exception.UnauthorizedException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Component
+public class RequestCurrentUserProvider implements CurrentUserProvider {
+
+    @Override
+    public Long getCurrentUserId() {
+        ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        if (attributes == null) {
+            throw new UnauthorizedException("인증이 필요합니다.");
+        }
+
+        HttpServletRequest request = attributes.getRequest();
+        Object currentUserId = request.getAttribute(AuthenticationContext.CURRENT_USER_ID);
+        if (currentUserId == null) {
+            throw new UnauthorizedException("인증이 필요합니다.");
+        }
+
+        return (Long) currentUserId;
+    }
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/user/service/UserPreferenceService.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/user/service/UserPreferenceService.java
@@ -1,0 +1,71 @@
+package com.example.foodaiflatformserver.user.service;
+
+import com.example.foodaiflatformserver.user.dto.UserPreferenceResponse;
+import com.example.foodaiflatformserver.user.dto.UserPreferenceUpsertRequest;
+import com.example.foodaiflatformserver.user.entity.DifficultyPreference;
+import com.example.foodaiflatformserver.user.entity.FavoriteCuisine;
+import com.example.foodaiflatformserver.user.entity.UserPreference;
+import com.example.foodaiflatformserver.user.exception.UserPreferenceNotFoundException;
+import com.example.foodaiflatformserver.user.repository.UserPreferenceRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+public class UserPreferenceService {
+
+    private final UserPreferenceRepository userPreferenceRepository;
+    private final CurrentUserProvider currentUserProvider;
+
+    public UserPreferenceService(UserPreferenceRepository userPreferenceRepository, CurrentUserProvider currentUserProvider) {
+        this.userPreferenceRepository = userPreferenceRepository;
+        this.currentUserProvider = currentUserProvider;
+    }
+
+    @Transactional
+    public UserPreferenceResponse upsert(UserPreferenceUpsertRequest request) {
+        Long userId = currentUserProvider.getCurrentUserId();
+        LocalDateTime updatedAt = LocalDateTime.now();
+        List<FavoriteCuisine> favoriteCuisines = request.favoriteCuisines().stream()
+                .map(FavoriteCuisine::valueOf)
+                .toList();
+        DifficultyPreference difficultyPreference = DifficultyPreference.valueOf(request.difficultyPreference());
+
+        UserPreference userPreference = userPreferenceRepository.findByUserId(userId)
+                .map(existing -> {
+                    existing.update(favoriteCuisines, difficultyPreference, request.quickMealPreferred(), updatedAt);
+                    return existing;
+                })
+                .orElseGet(() -> new UserPreference(
+                        userId,
+                        favoriteCuisines,
+                        difficultyPreference,
+                        request.quickMealPreferred(),
+                        updatedAt
+                ));
+
+        UserPreference saved = userPreferenceRepository.save(userPreference);
+        return toResponse(saved);
+    }
+
+    @Transactional(readOnly = true)
+    public UserPreferenceResponse getCurrentUserPreference() {
+        Long userId = currentUserProvider.getCurrentUserId();
+
+        return userPreferenceRepository.findByUserId(userId)
+                .map(this::toResponse)
+                .orElseThrow(() -> new UserPreferenceNotFoundException(userId));
+    }
+
+    private UserPreferenceResponse toResponse(UserPreference userPreference) {
+        return new UserPreferenceResponse(
+                userPreference.getUserId(),
+                userPreference.getFavoriteCuisines(),
+                userPreference.getDifficultyPreference(),
+                userPreference.isQuickMealPreferred(),
+                userPreference.getUpdatedAt()
+        );
+    }
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/user/service/UserPreferenceService.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/user/service/UserPreferenceService.java
@@ -7,8 +7,11 @@ import com.example.foodaiflatformserver.user.entity.FavoriteCuisine;
 import com.example.foodaiflatformserver.user.entity.UserPreference;
 import com.example.foodaiflatformserver.user.exception.UserPreferenceNotFoundException;
 import com.example.foodaiflatformserver.user.repository.UserPreferenceRepository;
+import com.example.foodaiflatformserver.common.support.KeyedLockExecutor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -18,13 +21,19 @@ public class UserPreferenceService {
 
     private final UserPreferenceRepository userPreferenceRepository;
     private final CurrentUserProvider currentUserProvider;
+    private final KeyedLockExecutor keyedLockExecutor;
+    private final TransactionTemplate transactionTemplate;
 
-    public UserPreferenceService(UserPreferenceRepository userPreferenceRepository, CurrentUserProvider currentUserProvider) {
+    public UserPreferenceService(UserPreferenceRepository userPreferenceRepository,
+                                 CurrentUserProvider currentUserProvider,
+                                 KeyedLockExecutor keyedLockExecutor,
+                                 TransactionTemplate transactionTemplate) {
         this.userPreferenceRepository = userPreferenceRepository;
         this.currentUserProvider = currentUserProvider;
+        this.keyedLockExecutor = keyedLockExecutor;
+        this.transactionTemplate = transactionTemplate;
     }
 
-    @Transactional
     public UserPreferenceResponse upsert(UserPreferenceUpsertRequest request) {
         Long userId = currentUserProvider.getCurrentUserId();
         LocalDateTime updatedAt = LocalDateTime.now();
@@ -33,21 +42,9 @@ public class UserPreferenceService {
                 .toList();
         DifficultyPreference difficultyPreference = DifficultyPreference.valueOf(request.difficultyPreference());
 
-        UserPreference userPreference = userPreferenceRepository.findByUserId(userId)
-                .map(existing -> {
-                    existing.update(favoriteCuisines, difficultyPreference, request.quickMealPreferred(), updatedAt);
-                    return existing;
-                })
-                .orElseGet(() -> new UserPreference(
-                        userId,
-                        favoriteCuisines,
-                        difficultyPreference,
-                        request.quickMealPreferred(),
-                        updatedAt
-                ));
-
-        UserPreference saved = userPreferenceRepository.save(userPreference);
-        return toResponse(saved);
+        return keyedLockExecutor.execute("preference:" + userId, () ->
+                upsertInternal(userId, favoriteCuisines, difficultyPreference, request.quickMealPreferred(), updatedAt)
+        );
     }
 
     @Transactional(readOnly = true)
@@ -67,5 +64,49 @@ public class UserPreferenceService {
                 userPreference.isQuickMealPreferred(),
                 userPreference.getUpdatedAt()
         );
+    }
+
+    private UserPreferenceResponse upsertInternal(Long userId,
+                                                  List<FavoriteCuisine> favoriteCuisines,
+                                                  DifficultyPreference difficultyPreference,
+                                                  boolean quickMealPreferred,
+                                                  LocalDateTime updatedAt) {
+        return userPreferenceRepository.findByUserId(userId)
+                .map(existing -> saveUpdated(userId, favoriteCuisines, difficultyPreference, quickMealPreferred, updatedAt))
+                .orElseGet(() -> createOrRecover(userId, favoriteCuisines, difficultyPreference, quickMealPreferred, updatedAt));
+    }
+
+    private UserPreferenceResponse saveUpdated(Long userId,
+                                               List<FavoriteCuisine> favoriteCuisines,
+                                               DifficultyPreference difficultyPreference,
+                                               boolean quickMealPreferred,
+                                               LocalDateTime updatedAt) {
+        return transactionTemplate.execute(status -> {
+            UserPreference existing = userPreferenceRepository.findByUserId(userId)
+                    .orElseThrow(() -> new UserPreferenceNotFoundException(userId));
+            existing.update(favoriteCuisines, difficultyPreference, quickMealPreferred, updatedAt);
+            return toResponse(userPreferenceRepository.save(existing));
+        });
+    }
+
+    private UserPreferenceResponse createOrRecover(Long userId,
+                                                   List<FavoriteCuisine> favoriteCuisines,
+                                                   DifficultyPreference difficultyPreference,
+                                                   boolean quickMealPreferred,
+                                                   LocalDateTime updatedAt) {
+        try {
+            return transactionTemplate.execute(status -> {
+                UserPreference created = new UserPreference(
+                        userId,
+                        favoriteCuisines,
+                        difficultyPreference,
+                        quickMealPreferred,
+                        updatedAt
+                );
+                return toResponse(userPreferenceRepository.saveAndFlush(created));
+            });
+        } catch (DataIntegrityViolationException exception) {
+            return saveUpdated(userId, favoriteCuisines, difficultyPreference, quickMealPreferred, updatedAt);
+        }
     }
 }

--- a/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/user/validation/EnumValue.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/user/validation/EnumValue.java
@@ -1,0 +1,23 @@
+package com.example.foodaiflatformserver.user.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = EnumValueValidator.class)
+public @interface EnumValue {
+
+    String message() default "허용되지 않은 enum 값입니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    Class<? extends Enum<?>> enumClass();
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/user/validation/EnumValueValidator.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/user/validation/EnumValueValidator.java
@@ -1,0 +1,29 @@
+package com.example.foodaiflatformserver.user.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class EnumValueValidator implements ConstraintValidator<EnumValue, String> {
+
+    private Set<String> allowedValues;
+
+    @Override
+    public void initialize(EnumValue annotation) {
+        allowedValues = Arrays.stream(annotation.enumClass().getEnumConstants())
+                .map(Enum::name)
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+
+        return allowedValues.contains(value);
+    }
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/user/validation/EnumValues.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/user/validation/EnumValues.java
@@ -1,0 +1,23 @@
+package com.example.foodaiflatformserver.user.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = EnumValuesValidator.class)
+public @interface EnumValues {
+
+    String message() default "허용되지 않은 enum 값이 포함되어 있습니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    Class<? extends Enum<?>> enumClass();
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/user/validation/EnumValuesValidator.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiflatformserver/user/validation/EnumValuesValidator.java
@@ -1,0 +1,30 @@
+package com.example.foodaiflatformserver.user.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class EnumValuesValidator implements ConstraintValidator<EnumValues, Collection<String>> {
+
+    private Set<String> allowedValues;
+
+    @Override
+    public void initialize(EnumValues annotation) {
+        allowedValues = Arrays.stream(annotation.enumClass().getEnumConstants())
+                .map(Enum::name)
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public boolean isValid(Collection<String> values, ConstraintValidatorContext context) {
+        if (values == null) {
+            return true;
+        }
+
+        return values.stream().allMatch(allowedValues::contains);
+    }
+}

--- a/food-ai-platform-server/src/main/resources/application.properties
+++ b/food-ai-platform-server/src/main/resources/application.properties
@@ -10,3 +10,5 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 
 app.jwt.secret=${APP_JWT_SECRET:food-ai-platform-jwt-secret-key-for-local-development-2026}
 app.jwt.expiration-seconds=${APP_JWT_EXPIRATION_SECONDS:3600}
+app.cors.allowed-origins=${APP_CORS_ALLOWED_ORIGINS:http://localhost:5500,http://localhost:3000,http://localhost:5173}
+app.cors.allowed-origin-patterns=${APP_CORS_ALLOWED_ORIGIN_PATTERNS:https://*.with-momo.com}

--- a/food-ai-platform-server/src/main/resources/application.properties
+++ b/food-ai-platform-server/src/main/resources/application.properties
@@ -7,3 +7,6 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.open-in-view=false
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
+
+app.jwt.secret=${APP_JWT_SECRET:food-ai-platform-jwt-secret-key-for-local-development-2026}
+app.jwt.expiration-seconds=${APP_JWT_EXPIRATION_SECONDS:3600}

--- a/food-ai-platform-server/src/test/java/com/example/foodaiflatformserver/auth/controller/AuthControllerTest.java
+++ b/food-ai-platform-server/src/test/java/com/example/foodaiflatformserver/auth/controller/AuthControllerTest.java
@@ -13,6 +13,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.context.WebApplicationContext;
 
+import static org.hamcrest.Matchers.hasItem;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -139,5 +140,26 @@ class AuthControllerTest {
                                 """))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.code").value("UNAUTHORIZED"));
+    }
+
+    @DisplayName("회원가입 요청의 문자열 길이가 컬럼 상한을 넘으면 검증 에러를 반환한다")
+    @Test
+    void returnsBadRequestForTooLongSignupFields() throws Exception {
+        String longUsername = "가".repeat(101);
+        String longEmailLocal = "a".repeat(244);
+
+        mockMvc.perform(post("/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "username": "%s",
+                                  "email": "%s@example.com",
+                                  "password": "password123!"
+                                }
+                                """.formatted(longUsername, longEmailLocal)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_REQUEST"))
+                .andExpect(jsonPath("$.details[*].field", hasItem("email")))
+                .andExpect(jsonPath("$.details[*].field", hasItem("username")));
     }
 }

--- a/food-ai-platform-server/src/test/java/com/example/foodaiflatformserver/auth/controller/AuthControllerTest.java
+++ b/food-ai-platform-server/src/test/java/com/example/foodaiflatformserver/auth/controller/AuthControllerTest.java
@@ -1,0 +1,143 @@
+package com.example.foodaiflatformserver.auth.controller;
+
+import com.example.foodaiflatformserver.auth.repository.UserAccountRepository;
+import com.example.foodaiflatformserver.user.repository.UserPreferenceRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
+
+@SpringBootTest
+class AuthControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserAccountRepository userAccountRepository;
+
+    @Autowired
+    private UserPreferenceRepository userPreferenceRepository;
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @BeforeEach
+    void setUp() {
+        userPreferenceRepository.deleteAll();
+        userAccountRepository.deleteAll();
+        mockMvc = webAppContextSetup(webApplicationContext).build();
+    }
+
+    @DisplayName("회원가입 후 로그인하면 JWT를 발급하고 내 정보를 조회할 수 있다")
+    @Test
+    void signupLoginAndReadMe() throws Exception {
+        mockMvc.perform(post("/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "username": "홍길동",
+                                  "email": "user@example.com",
+                                  "password": "password123!"
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.message").value("회원가입이 완료되었습니다."))
+                .andExpect(jsonPath("$.user.username").value("홍길동"))
+                .andExpect(jsonPath("$.user.email").value("user@example.com"));
+
+        String loginResponse = mockMvc.perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "email": "user@example.com",
+                                  "password": "password123!"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("로그인 성공"))
+                .andExpect(jsonPath("$.token_type").value("Bearer"))
+                .andExpect(jsonPath("$.access_token").isNotEmpty())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        JsonNode jsonNode = objectMapper.readTree(loginResponse);
+        Long userId = jsonNode.get("user").get("user_id").asLong();
+        String accessToken = jsonNode.get("access_token").asText();
+
+        mockMvc.perform(get("/auth/me")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.user_id").value(userId))
+                .andExpect(jsonPath("$.username").value("홍길동"))
+                .andExpect(jsonPath("$.email").value("user@example.com"));
+    }
+
+    @DisplayName("중복 이메일 회원가입은 충돌 에러를 반환한다")
+    @Test
+    void returnsConflictForDuplicateEmail() throws Exception {
+        mockMvc.perform(post("/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "username": "홍길동",
+                                  "email": "user@example.com",
+                                  "password": "password123!"
+                                }
+                                """))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(post("/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "username": "김영희",
+                                  "email": "user@example.com",
+                                  "password": "password123!"
+                                }
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("CONFLICT"));
+    }
+
+    @DisplayName("잘못된 로그인 정보는 인증 에러를 반환한다")
+    @Test
+    void returnsUnauthorizedForInvalidLogin() throws Exception {
+        mockMvc.perform(post("/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "username": "홍길동",
+                                  "email": "user@example.com",
+                                  "password": "password123!"
+                                }
+                                """))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "email": "user@example.com",
+                                  "password": "wrong-password"
+                                }
+                                """))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("UNAUTHORIZED"));
+    }
+}

--- a/food-ai-platform-server/src/test/java/com/example/foodaiflatformserver/auth/controller/CorsIntegrationTest.java
+++ b/food-ai-platform-server/src/test/java/com/example/foodaiflatformserver/auth/controller/CorsIntegrationTest.java
@@ -1,0 +1,35 @@
+package com.example.foodaiflatformserver.auth.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
+
+@SpringBootTest
+class CorsIntegrationTest {
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @DisplayName("프론트 origin의 preflight 요청은 인증 없이 허용된다")
+    @Test
+    void allowsPreflightFromFrontendOrigin() throws Exception {
+        MockMvc mockMvc = webAppContextSetup(webApplicationContext).build();
+
+        mockMvc.perform(options("/users/me/preferences")
+                        .header(HttpHeaders.ORIGIN, "http://localhost:5500")
+                        .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "PUT")
+                        .header(HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS, "Authorization, Content-Type"))
+                .andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "http://localhost:5500"))
+                .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true"));
+    }
+}

--- a/food-ai-platform-server/src/test/java/com/example/foodaiflatformserver/auth/service/AuthServiceTest.java
+++ b/food-ai-platform-server/src/test/java/com/example/foodaiflatformserver/auth/service/AuthServiceTest.java
@@ -1,0 +1,42 @@
+package com.example.foodaiflatformserver.auth.service;
+
+import com.example.foodaiflatformserver.auth.dto.AuthSignupRequest;
+import com.example.foodaiflatformserver.auth.exception.DuplicateEmailException;
+import com.example.foodaiflatformserver.auth.repository.UserAccountRepository;
+import com.example.foodaiflatformserver.auth.security.JwtTokenProvider;
+import com.example.foodaiflatformserver.common.support.KeyedLockExecutor;
+import com.example.foodaiflatformserver.user.service.CurrentUserProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AuthServiceTest {
+
+    private final UserAccountRepository userAccountRepository = mock(UserAccountRepository.class);
+    private final JwtTokenProvider jwtTokenProvider = mock(JwtTokenProvider.class);
+    private final CurrentUserProvider currentUserProvider = mock(CurrentUserProvider.class);
+    private final AuthService authService = new AuthService(
+            userAccountRepository,
+            jwtTokenProvider,
+            currentUserProvider,
+            new KeyedLockExecutor()
+    );
+
+    @DisplayName("회원가입 저장 중 유니크 제약 충돌이 나면 중복 이메일 예외로 변환한다")
+    @Test
+    void convertsDuplicateEmailConstraintToConflict() {
+        AuthSignupRequest request = new AuthSignupRequest("홍길동", "user@example.com", "password123!");
+        when(userAccountRepository.existsByEmail(request.email())).thenReturn(false);
+        when(userAccountRepository.saveAndFlush(any()))
+                .thenThrow(new DataIntegrityViolationException("duplicate email"));
+
+        assertThatThrownBy(() -> authService.signup(request))
+                .isInstanceOf(DuplicateEmailException.class)
+                .hasMessageContaining("이미 가입된 이메일입니다.");
+    }
+}

--- a/food-ai-platform-server/src/test/java/com/example/foodaiflatformserver/user/controller/UserPreferenceControllerTest.java
+++ b/food-ai-platform-server/src/test/java/com/example/foodaiflatformserver/user/controller/UserPreferenceControllerTest.java
@@ -1,0 +1,193 @@
+package com.example.foodaiflatformserver.user.controller;
+
+import com.example.foodaiflatformserver.auth.repository.UserAccountRepository;
+import com.example.foodaiflatformserver.user.repository.UserPreferenceRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
+
+@SpringBootTest
+class UserPreferenceControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserAccountRepository userAccountRepository;
+
+    @Autowired
+    private UserPreferenceRepository userPreferenceRepository;
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @BeforeEach
+    void setUp() {
+        userPreferenceRepository.deleteAll();
+        userAccountRepository.deleteAll();
+        mockMvc = webAppContextSetup(webApplicationContext).build();
+    }
+
+    @DisplayName("선호 정보를 저장한 뒤 즉시 조회할 수 있다")
+    @Test
+    void savesAndReadsPreference() throws Exception {
+        AuthSession authSession = signupAndLogin();
+
+        mockMvc.perform(put("/users/me/preferences")
+                        .header("Authorization", "Bearer " + authSession.accessToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "favorite_cuisines": ["KOREAN", "JAPANESE"],
+                                  "difficulty_preference": "EASY",
+                                  "quick_meal_preferred": true
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.user_id").value(authSession.userId()))
+                .andExpect(jsonPath("$.favorite_cuisines", hasSize(2)))
+                .andExpect(jsonPath("$.favorite_cuisines[0]").value("KOREAN"))
+                .andExpect(jsonPath("$.favorite_cuisines[1]").value("JAPANESE"))
+                .andExpect(jsonPath("$.difficulty_preference").value("EASY"))
+                .andExpect(jsonPath("$.quick_meal_preferred").value(true))
+                .andExpect(jsonPath("$.updated_at").exists());
+
+        mockMvc.perform(get("/users/me/preferences")
+                        .header("Authorization", "Bearer " + authSession.accessToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.user_id").value(authSession.userId()))
+                .andExpect(jsonPath("$.favorite_cuisines", hasSize(2)))
+                .andExpect(jsonPath("$.favorite_cuisines[0]").value("KOREAN"))
+                .andExpect(jsonPath("$.favorite_cuisines[1]").value("JAPANESE"))
+                .andExpect(jsonPath("$.difficulty_preference").value("EASY"))
+                .andExpect(jsonPath("$.quick_meal_preferred").value(true))
+                .andExpect(jsonPath("$.updated_at").exists());
+    }
+
+    @DisplayName("같은 사용자가 다시 저장하면 기존 선호 정보가 갱신된다")
+    @Test
+    void upsertsExistingPreference() throws Exception {
+        AuthSession authSession = signupAndLogin();
+
+        mockMvc.perform(put("/users/me/preferences")
+                        .header("Authorization", "Bearer " + authSession.accessToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "favorite_cuisines": ["KOREAN", "JAPANESE"],
+                                  "difficulty_preference": "EASY",
+                                  "quick_meal_preferred": true
+                                }
+                                """))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(put("/users/me/preferences")
+                        .header("Authorization", "Bearer " + authSession.accessToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "favorite_cuisines": ["WESTERN"],
+                                  "difficulty_preference": "HARD",
+                                  "quick_meal_preferred": false
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.favorite_cuisines", hasSize(1)))
+                .andExpect(jsonPath("$.favorite_cuisines[0]").value("WESTERN"))
+                .andExpect(jsonPath("$.difficulty_preference").value("HARD"))
+                .andExpect(jsonPath("$.quick_meal_preferred").value(false));
+
+        mockMvc.perform(get("/users/me/preferences")
+                        .header("Authorization", "Bearer " + authSession.accessToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.favorite_cuisines", hasSize(1)))
+                .andExpect(jsonPath("$.favorite_cuisines[0]").value("WESTERN"))
+                .andExpect(jsonPath("$.difficulty_preference").value("HARD"))
+                .andExpect(jsonPath("$.quick_meal_preferred").value(false));
+    }
+
+    @DisplayName("잘못된 enum 값은 validation 에러를 반환한다")
+    @Test
+    void returnsValidationErrorForInvalidEnum() throws Exception {
+        AuthSession authSession = signupAndLogin();
+
+        mockMvc.perform(put("/users/me/preferences")
+                        .header("Authorization", "Bearer " + authSession.accessToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "favorite_cuisines": ["KOREAN", "THAI"],
+                                  "difficulty_preference": "VERY_EASY",
+                                  "quick_meal_preferred": true
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_REQUEST"))
+                .andExpect(jsonPath("$.details", hasSize(2)))
+                .andExpect(jsonPath("$.details[0].field").value("difficultyPreference"))
+                .andExpect(jsonPath("$.details[1].field").value("favoriteCuisines"));
+    }
+
+    @DisplayName("토큰 없이 선호 조회를 호출하면 인증 에러를 반환한다")
+    @Test
+    void returnsUnauthorizedWithoutToken() throws Exception {
+        mockMvc.perform(get("/users/me/preferences"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("UNAUTHORIZED"));
+    }
+
+    private AuthSession signupAndLogin() throws Exception {
+        mockMvc.perform(post("/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "username": "홍길동",
+                                  "email": "user@example.com",
+                                  "password": "password123!"
+                                }
+                                """))
+                .andExpect(status().isCreated());
+
+        String loginResponse = mockMvc.perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "email": "user@example.com",
+                                  "password": "password123!"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        JsonNode jsonNode = objectMapper.readTree(loginResponse);
+        return new AuthSession(
+                jsonNode.get("access_token").asText(),
+                jsonNode.get("user").get("user_id").asLong()
+        );
+    }
+
+    private record AuthSession(
+            String accessToken,
+            Long userId
+    ) {
+    }
+}

--- a/food-ai-platform-server/src/test/java/com/example/foodaiflatformserver/user/service/UserPreferenceServiceTest.java
+++ b/food-ai-platform-server/src/test/java/com/example/foodaiflatformserver/user/service/UserPreferenceServiceTest.java
@@ -1,0 +1,72 @@
+package com.example.foodaiflatformserver.user.service;
+
+import com.example.foodaiflatformserver.common.support.KeyedLockExecutor;
+import com.example.foodaiflatformserver.user.dto.UserPreferenceResponse;
+import com.example.foodaiflatformserver.user.dto.UserPreferenceUpsertRequest;
+import com.example.foodaiflatformserver.user.entity.DifficultyPreference;
+import com.example.foodaiflatformserver.user.entity.FavoriteCuisine;
+import com.example.foodaiflatformserver.user.entity.UserPreference;
+import com.example.foodaiflatformserver.user.repository.UserPreferenceRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class UserPreferenceServiceTest {
+
+    private final UserPreferenceRepository userPreferenceRepository = mock(UserPreferenceRepository.class);
+    private final CurrentUserProvider currentUserProvider = mock(CurrentUserProvider.class);
+    private final PlatformTransactionManager transactionManager = mock(PlatformTransactionManager.class);
+    private final UserPreferenceService userPreferenceService = new UserPreferenceService(
+            userPreferenceRepository,
+            currentUserProvider,
+            new KeyedLockExecutor(),
+            new TransactionTemplate(transactionManager)
+    );
+
+    @DisplayName("최초 취향 저장 중 유니크 제약 충돌이 나면 기존 데이터를 다시 조회해 갱신한다")
+    @Test
+    void recoversFromDuplicatePreferenceInsert() {
+        Long userId = 1L;
+        TransactionStatus transactionStatus = mock(TransactionStatus.class);
+        UserPreferenceUpsertRequest request = new UserPreferenceUpsertRequest(
+                List.of("WESTERN"),
+                "HARD",
+                false
+        );
+        UserPreference existing = new UserPreference(
+                userId,
+                List.of(FavoriteCuisine.KOREAN),
+                DifficultyPreference.EASY,
+                true,
+                LocalDateTime.now().minusDays(1)
+        );
+
+        when(transactionManager.getTransaction(any())).thenReturn(transactionStatus);
+        when(currentUserProvider.getCurrentUserId()).thenReturn(userId);
+        when(userPreferenceRepository.findByUserId(userId))
+                .thenReturn(Optional.empty())
+                .thenReturn(Optional.of(existing));
+        when(userPreferenceRepository.saveAndFlush(any(UserPreference.class)))
+                .thenThrow(new DataIntegrityViolationException("duplicate user_id"));
+        when(userPreferenceRepository.save(existing)).thenAnswer(invocation -> invocation.getArgument(0));
+
+        UserPreferenceResponse response = userPreferenceService.upsert(request);
+
+        assertThat(response.userId()).isEqualTo(userId);
+        assertThat(response.favoriteCuisines()).containsExactly(FavoriteCuisine.WESTERN);
+        assertThat(response.difficultyPreference()).isEqualTo(DifficultyPreference.HARD);
+        assertThat(response.quickMealPreferred()).isFalse();
+    }
+}

--- a/food-ai-platform-server/src/test/resources/application.properties
+++ b/food-ai-platform-server/src/test/resources/application.properties
@@ -9,3 +9,5 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
 
 app.jwt.secret=test-jwt-secret-key
 app.jwt.expiration-seconds=3600
+app.cors.allowed-origins=http://localhost:5500,http://localhost:3000,http://localhost:5173
+app.cors.allowed-origin-patterns=https://*.with-momo.com

--- a/food-ai-platform-server/src/test/resources/application.properties
+++ b/food-ai-platform-server/src/test/resources/application.properties
@@ -6,3 +6,6 @@ spring.datasource.driver-class-name=org.h2.Driver
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.open-in-view=false
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
+
+app.jwt.secret=test-jwt-secret-key
+app.jwt.expiration-seconds=3600


### PR DESCRIPTION
## 목적
온보딩 취향 정보를 저장하고 조회하는 API를 구현한다.

## 작업 내용
- `PUT /users/me/preferences`
- `GET /users/me/preferences`
- 선호 카테고리, 난이도, 간편식 선호 여부 저장
- 동일 사용자 재저장 시 upsert 처리
- enum validation 적용

## 완료 조건
- 저장 후 즉시 조회 가능하다
- 재저장 시 기존 값이 갱신된다
- 잘못된 enum 값은 validation 에러를 반환한다
