### PR TITLE
feat: 사용자 레시피 선택 이력 API 구현

### DIFF
--- a/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/userrecipe/controller/UserRecipeController.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/userrecipe/controller/UserRecipeController.java
@@ -1,0 +1,43 @@
+package com.example.foodaiplatformserver.userrecipe.controller;
+
+import com.example.foodaiplatformserver.userrecipe.dto.UserRecipeCreateRequest;
+import com.example.foodaiplatformserver.userrecipe.dto.UserRecipeResponse;
+import com.example.foodaiplatformserver.userrecipe.service.UserRecipeService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Validated
+@RestController
+@RequestMapping("/user-recipes")
+public class UserRecipeController {
+
+    private final UserRecipeService userRecipeService;
+
+    public UserRecipeController(UserRecipeService userRecipeService) {
+        this.userRecipeService = userRecipeService;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public UserRecipeResponse create(@Valid @RequestBody UserRecipeCreateRequest request) {
+        return userRecipeService.create(request);
+    }
+
+    @GetMapping
+    public List<UserRecipeResponse> getMyHistories(
+            @RequestParam(name = "limit", required = false) @Min(value = 1, message = "limit는 1 이상이어야 합니다.") Integer limit
+    ) {
+        return userRecipeService.getMyHistories(limit);
+    }
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/userrecipe/dto/UserRecipeCreateRequest.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/userrecipe/dto/UserRecipeCreateRequest.java
@@ -1,0 +1,20 @@
+package com.example.foodaiplatformserver.userrecipe.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record UserRecipeCreateRequest(
+        @JsonProperty("recipe_id")
+        @NotNull(message = "레시피 ID는 필수입니다.")
+        Long recipeId,
+
+        @JsonProperty("recipe_name")
+        @NotBlank(message = "레시피 이름은 필수입니다.")
+        String recipeName,
+
+        @JsonProperty("category")
+        @NotBlank(message = "카테고리는 필수입니다.")
+        String category
+) {
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/userrecipe/dto/UserRecipeCreateRequest.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/userrecipe/dto/UserRecipeCreateRequest.java
@@ -3,6 +3,7 @@ package com.example.foodaiplatformserver.userrecipe.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 public record UserRecipeCreateRequest(
         @JsonProperty("recipe_id")
@@ -11,10 +12,12 @@ public record UserRecipeCreateRequest(
 
         @JsonProperty("recipe_name")
         @NotBlank(message = "레시피 이름은 필수입니다.")
+        @Size(max = 255, message = "레시피 이름은 255자 이하여야 합니다.")
         String recipeName,
 
         @JsonProperty("category")
         @NotBlank(message = "카테고리는 필수입니다.")
+        @Size(max = 100, message = "카테고리는 100자 이하여야 합니다.")
         String category
 ) {
 }

--- a/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/userrecipe/dto/UserRecipeResponse.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/userrecipe/dto/UserRecipeResponse.java
@@ -1,0 +1,23 @@
+package com.example.foodaiplatformserver.userrecipe.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.LocalDateTime;
+
+public record UserRecipeResponse(
+        @JsonProperty("history_id")
+        Long historyId,
+
+        @JsonProperty("recipe_id")
+        Long recipeId,
+
+        @JsonProperty("recipe_name")
+        String recipeName,
+
+        @JsonProperty("category")
+        String category,
+
+        @JsonProperty("selected_at")
+        LocalDateTime selectedAt
+) {
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/userrecipe/entity/UserRecipeHistory.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/userrecipe/entity/UserRecipeHistory.java
@@ -5,16 +5,23 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "user_recipe_histories")
+@Table(
+        name = "user_recipes",
+        indexes = {
+                @Index(name = "idx_user_recipes_user_selected_at", columnList = "user_id, selected_at")
+        }
+)
 public class UserRecipeHistory {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "history_id")
     private Long id;
 
     @Column(name = "user_id", nullable = false)

--- a/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/userrecipe/entity/UserRecipeHistory.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/userrecipe/entity/UserRecipeHistory.java
@@ -1,0 +1,73 @@
+package com.example.foodaiplatformserver.userrecipe.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "user_recipe_histories")
+public class UserRecipeHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "recipe_id", nullable = false)
+    private Long recipeId;
+
+    @Column(name = "recipe_name", nullable = false, length = 255)
+    private String recipeName;
+
+    @Column(name = "category", nullable = false, length = 100)
+    private String category;
+
+    @Column(name = "selected_at", nullable = false)
+    private LocalDateTime selectedAt;
+
+    protected UserRecipeHistory() {
+    }
+
+    public UserRecipeHistory(Long userId,
+                             Long recipeId,
+                             String recipeName,
+                             String category,
+                             LocalDateTime selectedAt) {
+        this.userId = userId;
+        this.recipeId = recipeId;
+        this.recipeName = recipeName;
+        this.category = category;
+        this.selectedAt = selectedAt;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public Long getRecipeId() {
+        return recipeId;
+    }
+
+    public String getRecipeName() {
+        return recipeName;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public LocalDateTime getSelectedAt() {
+        return selectedAt;
+    }
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/userrecipe/repository/UserRecipeHistoryRepository.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/userrecipe/repository/UserRecipeHistoryRepository.java
@@ -1,0 +1,12 @@
+package com.example.foodaiplatformserver.userrecipe.repository;
+
+import com.example.foodaiplatformserver.userrecipe.entity.UserRecipeHistory;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface UserRecipeHistoryRepository extends JpaRepository<UserRecipeHistory, Long> {
+
+    List<UserRecipeHistory> findByUserIdOrderBySelectedAtDescIdDesc(Long userId, Pageable pageable);
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/userrecipe/service/UserRecipeService.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/userrecipe/service/UserRecipeService.java
@@ -1,0 +1,66 @@
+package com.example.foodaiplatformserver.userrecipe.service;
+
+import com.example.foodaiplatformserver.user.service.CurrentUserProvider;
+import com.example.foodaiplatformserver.userrecipe.dto.UserRecipeCreateRequest;
+import com.example.foodaiplatformserver.userrecipe.dto.UserRecipeResponse;
+import com.example.foodaiplatformserver.userrecipe.entity.UserRecipeHistory;
+import com.example.foodaiplatformserver.userrecipe.repository.UserRecipeHistoryRepository;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+public class UserRecipeService {
+
+    private static final int DEFAULT_LIMIT = 20;
+
+    private final UserRecipeHistoryRepository userRecipeHistoryRepository;
+    private final CurrentUserProvider currentUserProvider;
+
+    public UserRecipeService(UserRecipeHistoryRepository userRecipeHistoryRepository,
+                             CurrentUserProvider currentUserProvider) {
+        this.userRecipeHistoryRepository = userRecipeHistoryRepository;
+        this.currentUserProvider = currentUserProvider;
+    }
+
+    @Transactional
+    public UserRecipeResponse create(UserRecipeCreateRequest request) {
+        Long userId = currentUserProvider.getCurrentUserId();
+        UserRecipeHistory history = new UserRecipeHistory(
+                userId,
+                request.recipeId(),
+                request.recipeName(),
+                request.category(),
+                LocalDateTime.now()
+        );
+
+        return toResponse(userRecipeHistoryRepository.save(history));
+    }
+
+    @Transactional(readOnly = true)
+    public List<UserRecipeResponse> getMyHistories(Integer limit) {
+        Long userId = currentUserProvider.getCurrentUserId();
+        int resolvedLimit = limit == null ? DEFAULT_LIMIT : limit;
+
+        return userRecipeHistoryRepository.findByUserIdOrderBySelectedAtDescIdDesc(
+                        userId,
+                        PageRequest.of(0, resolvedLimit)
+                )
+                .stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    private UserRecipeResponse toResponse(UserRecipeHistory history) {
+        return new UserRecipeResponse(
+                history.getId(),
+                history.getRecipeId(),
+                history.getRecipeName(),
+                history.getCategory(),
+                history.getSelectedAt()
+        );
+    }
+}

--- a/food-ai-platform-server/src/test/java/com/example/foodaiplatformserver/userrecipe/controller/UserRecipeControllerTest.java
+++ b/food-ai-platform-server/src/test/java/com/example/foodaiplatformserver/userrecipe/controller/UserRecipeControllerTest.java
@@ -1,0 +1,175 @@
+package com.example.foodaiplatformserver.userrecipe.controller;
+
+import com.example.foodaiplatformserver.auth.repository.UserAccountRepository;
+import com.example.foodaiplatformserver.user.repository.UserPreferenceRepository;
+import com.example.foodaiplatformserver.userrecipe.repository.UserRecipeHistoryRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
+
+@SpringBootTest
+class UserRecipeControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserAccountRepository userAccountRepository;
+
+    @Autowired
+    private UserPreferenceRepository userPreferenceRepository;
+
+    @Autowired
+    private UserRecipeHistoryRepository userRecipeHistoryRepository;
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @BeforeEach
+    void setUp() {
+        userRecipeHistoryRepository.deleteAll();
+        userPreferenceRepository.deleteAll();
+        userAccountRepository.deleteAll();
+        mockMvc = webAppContextSetup(webApplicationContext).build();
+    }
+
+    @DisplayName("선택한 레시피 이력을 저장하고 최신순으로 limit 만큼 조회한다")
+    @Test
+    void savesAndReadsHistoriesWithLimitInLatestOrder() throws Exception {
+        AuthSession user = signupAndLogin("user1@example.com");
+
+        mockMvc.perform(post("/user-recipes")
+                        .header("Authorization", "Bearer " + user.accessToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "recipe_id": 101,
+                                  "recipe_name": "첫 번째 레시피",
+                                  "category": "한식"
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.history_id").isNumber())
+                .andExpect(jsonPath("$.recipe_id").value(101))
+                .andExpect(jsonPath("$.recipe_name").value("첫 번째 레시피"))
+                .andExpect(jsonPath("$.category").value("한식"))
+                .andExpect(jsonPath("$.selected_at").exists());
+
+        mockMvc.perform(post("/user-recipes")
+                        .header("Authorization", "Bearer " + user.accessToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "recipe_id": 102,
+                                  "recipe_name": "두 번째 레시피",
+                                  "category": "중식"
+                                }
+                                """))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/user-recipes")
+                        .header("Authorization", "Bearer " + user.accessToken())
+                        .param("limit", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].recipe_id").value(102))
+                .andExpect(jsonPath("$[0].recipe_name").value("두 번째 레시피"));
+    }
+
+    @DisplayName("다른 사용자의 레시피 이력은 조회되지 않는다")
+    @Test
+    void returnsOnlyCurrentUserHistories() throws Exception {
+        AuthSession firstUser = signupAndLogin("user1@example.com");
+        AuthSession secondUser = signupAndLogin("user2@example.com");
+
+        createHistory(firstUser.accessToken(), 101, "첫 사용자 레시피", "한식");
+        createHistory(secondUser.accessToken(), 201, "둘째 사용자 레시피", "양식");
+
+        mockMvc.perform(get("/user-recipes")
+                        .header("Authorization", "Bearer " + firstUser.accessToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].recipe_id").value(101))
+                .andExpect(jsonPath("$[0].recipe_name").value("첫 사용자 레시피"));
+    }
+
+    @DisplayName("limit가 1 미만이면 검증 에러를 반환한다")
+    @Test
+    void returnsValidationErrorForInvalidLimit() throws Exception {
+        AuthSession user = signupAndLogin("user1@example.com");
+
+        mockMvc.perform(get("/user-recipes")
+                        .header("Authorization", "Bearer " + user.accessToken())
+                        .param("limit", "0"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_REQUEST"));
+    }
+
+    private void createHistory(String accessToken, int recipeId, String recipeName, String category) throws Exception {
+        mockMvc.perform(post("/user-recipes")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "recipe_id": %d,
+                                  "recipe_name": "%s",
+                                  "category": "%s"
+                                }
+                                """.formatted(recipeId, recipeName, category)))
+                .andExpect(status().isCreated());
+    }
+
+    private AuthSession signupAndLogin(String email) throws Exception {
+        mockMvc.perform(post("/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "username": "%s",
+                                  "email": "%s",
+                                  "password": "password123!"
+                                }
+                                """.formatted(email, email)))
+                .andExpect(status().isCreated());
+
+        String loginResponse = mockMvc.perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "email": "%s",
+                                  "password": "password123!"
+                                }
+                                """.formatted(email)))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        JsonNode jsonNode = objectMapper.readTree(loginResponse);
+        return new AuthSession(
+                jsonNode.get("access_token").asText(),
+                jsonNode.get("user").get("user_id").asLong()
+        );
+    }
+
+    private record AuthSession(
+            String accessToken,
+            Long userId
+    ) {
+    }
+}

--- a/food-ai-platform-server/src/test/java/com/example/foodaiplatformserver/userrecipe/controller/UserRecipeControllerTest.java
+++ b/food-ai-platform-server/src/test/java/com/example/foodaiplatformserver/userrecipe/controller/UserRecipeControllerTest.java
@@ -15,6 +15,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.context.WebApplicationContext;
 
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.hasItem;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -119,6 +120,29 @@ class UserRecipeControllerTest {
                         .param("limit", "0"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("INVALID_REQUEST"));
+    }
+
+    @DisplayName("레시피 이름이나 카테고리가 너무 길면 검증 에러를 반환한다")
+    @Test
+    void returnsValidationErrorForTooLongFields() throws Exception {
+        AuthSession user = signupAndLogin("user1@example.com");
+        String longRecipeName = "가".repeat(256);
+        String longCategory = "나".repeat(101);
+
+        mockMvc.perform(post("/user-recipes")
+                        .header("Authorization", "Bearer " + user.accessToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "recipe_id": 101,
+                                  "recipe_name": "%s",
+                                  "category": "%s"
+                                }
+                                """.formatted(longRecipeName, longCategory)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_REQUEST"))
+                .andExpect(jsonPath("$.details[*].field", hasItem("category")))
+                .andExpect(jsonPath("$.details[*].field", hasItem("recipeName")));
     }
 
     private void createHistory(String accessToken, int recipeId, String recipeName, String category) throws Exception {


### PR DESCRIPTION
## 작업 내용
- 사용자 레시피 선택 이력 저장 API 추가
- 사용자 레시피 선택 이력 조회 API 추가
- limit 파라미터와 최신순 조회 적용
- 로그인 사용자 기준으로 데이터 조회 범위 제한
- 통합 테스트 추가

## 테스트
- ./gradlew test --tests com.example.foodaiplatformserver.userrecipe.controller.UserRecipeControllerTest