### PR TITLE
fridge-items API 복구 및 통합 테스트 추가

### DIFF
--- a/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/fridgeitem/controller/FridgeItemController.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/fridgeitem/controller/FridgeItemController.java
@@ -1,0 +1,70 @@
+package com.example.foodaiplatformserver.fridgeitem.controller;
+
+import com.example.foodaiplatformserver.fridgeitem.dto.FridgeItemResponse;
+import com.example.foodaiplatformserver.fridgeitem.dto.FridgeItemSaveRequest;
+import com.example.foodaiplatformserver.fridgeitem.dto.FridgeItemSummaryResponse;
+import com.example.foodaiplatformserver.fridgeitem.entity.ItemStatus;
+import com.example.foodaiplatformserver.fridgeitem.entity.StorageLocation;
+import com.example.foodaiplatformserver.fridgeitem.service.FridgeItemService;
+import com.example.foodaiplatformserver.user.validation.EnumValue;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Validated
+@RestController
+@RequestMapping("/fridge-items")
+public class FridgeItemController {
+
+    private final FridgeItemService fridgeItemService;
+
+    public FridgeItemController(FridgeItemService fridgeItemService) {
+        this.fridgeItemService = fridgeItemService;
+    }
+
+    @GetMapping("/summary")
+    public FridgeItemSummaryResponse getSummary() {
+        return fridgeItemService.getSummary();
+    }
+
+    @GetMapping
+    public List<FridgeItemResponse> getItems(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(name = "storage_location", required = false)
+            @EnumValue(enumClass = StorageLocation.class, message = "보관 위치 값이 올바르지 않습니다.") String storageLocation,
+            @RequestParam(required = false)
+            @EnumValue(enumClass = ItemStatus.class, message = "식품 상태 값이 올바르지 않습니다.") String status
+    ) {
+        return fridgeItemService.getItems(keyword, storageLocation, status);
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public FridgeItemResponse create(@Valid @RequestBody FridgeItemSaveRequest request) {
+        return fridgeItemService.create(request);
+    }
+
+    @PutMapping("/{itemId}")
+    public FridgeItemResponse update(@PathVariable Long itemId,
+                                     @Valid @RequestBody FridgeItemSaveRequest request) {
+        return fridgeItemService.update(itemId, request);
+    }
+
+    @DeleteMapping("/{itemId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable Long itemId) {
+        fridgeItemService.delete(itemId);
+    }
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/fridgeitem/dto/FridgeItemResponse.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/fridgeitem/dto/FridgeItemResponse.java
@@ -1,0 +1,54 @@
+package com.example.foodaiplatformserver.fridgeitem.dto;
+
+import com.example.foodaiplatformserver.fridgeitem.entity.FridgeItem;
+import com.example.foodaiplatformserver.fridgeitem.service.FridgeItemStatusCalculator;
+import com.example.foodaiplatformserver.fridgeitem.service.FridgeItemStatusResult;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.LocalDate;
+
+public record FridgeItemResponse(
+        @JsonProperty("item_id")
+        Long itemId,
+
+        @JsonProperty("name")
+        String name,
+
+        @JsonProperty("quantity")
+        String quantity,
+
+        @JsonProperty("storage_location")
+        String storageLocation,
+
+        @JsonProperty("registered_date")
+        LocalDate registeredDate,
+
+        @JsonProperty("expiration_date")
+        LocalDate expirationDate,
+
+        @JsonProperty("status")
+        String status,
+
+        @JsonProperty("d_day")
+        int dDay,
+
+        @JsonProperty("status_text")
+        String statusText
+) {
+
+    public static FridgeItemResponse from(FridgeItem fridgeItem, FridgeItemStatusCalculator statusCalculator) {
+        FridgeItemStatusResult statusResult = statusCalculator.calculate(fridgeItem.getExpirationDate());
+
+        return new FridgeItemResponse(
+                fridgeItem.getId(),
+                fridgeItem.getName(),
+                fridgeItem.getQuantity(),
+                fridgeItem.getStorageLocation().name(),
+                fridgeItem.getRegisteredDate(),
+                fridgeItem.getExpirationDate(),
+                statusResult.status().name(),
+                statusResult.dDay(),
+                statusResult.statusText()
+        );
+    }
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/fridgeitem/dto/FridgeItemSaveRequest.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/fridgeitem/dto/FridgeItemSaveRequest.java
@@ -1,0 +1,32 @@
+package com.example.foodaiplatformserver.fridgeitem.dto;
+
+import com.example.foodaiplatformserver.fridgeitem.entity.StorageLocation;
+import com.example.foodaiplatformserver.user.validation.EnumValue;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
+
+public record FridgeItemSaveRequest(
+        @JsonProperty("name")
+        @NotBlank(message = "식품명은 필수입니다.")
+        @Size(max = 100, message = "식품명은 100자 이하여야 합니다.")
+        String name,
+
+        @JsonProperty("quantity")
+        @NotBlank(message = "수량은 필수입니다.")
+        @Size(max = 50, message = "수량은 50자 이하여야 합니다.")
+        String quantity,
+
+        @JsonProperty("storage_location")
+        @NotNull(message = "보관 위치는 필수입니다.")
+        @EnumValue(enumClass = StorageLocation.class, message = "보관 위치 값이 올바르지 않습니다.")
+        String storageLocation,
+
+        @JsonProperty("expiration_date")
+        @NotNull(message = "유통기한은 필수입니다.")
+        LocalDate expirationDate
+) {
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/fridgeitem/dto/FridgeItemSummaryItemResponse.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/fridgeitem/dto/FridgeItemSummaryItemResponse.java
@@ -1,0 +1,18 @@
+package com.example.foodaiplatformserver.fridgeitem.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record FridgeItemSummaryItemResponse(
+        @JsonProperty("item_id")
+        Long itemId,
+
+        @JsonProperty("name")
+        String name,
+
+        @JsonProperty("d_day")
+        int dDay,
+
+        @JsonProperty("status_text")
+        String statusText
+) {
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/fridgeitem/dto/FridgeItemSummaryResponse.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/fridgeitem/dto/FridgeItemSummaryResponse.java
@@ -1,0 +1,27 @@
+package com.example.foodaiplatformserver.fridgeitem.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Map;
+
+public record FridgeItemSummaryResponse(
+        @JsonProperty("total_count")
+        int totalCount,
+
+        @JsonProperty("expiring_soon_count")
+        int expiringSoonCount,
+
+        @JsonProperty("expired_count")
+        int expiredCount,
+
+        @JsonProperty("location_stats")
+        Map<String, Integer> locationStats,
+
+        @JsonProperty("expiring_soon_items")
+        List<FridgeItemSummaryItemResponse> expiringSoonItems,
+
+        @JsonProperty("expired_items")
+        List<FridgeItemSummaryItemResponse> expiredItems
+) {
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/fridgeitem/entity/FridgeItem.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/fridgeitem/entity/FridgeItem.java
@@ -61,6 +61,16 @@ public class FridgeItem {
         this.expirationDate = expirationDate;
     }
 
+    public void update(String name,
+                       String quantity,
+                       StorageLocation storageLocation,
+                       LocalDate expirationDate) {
+        this.name = name;
+        this.quantity = quantity;
+        this.storageLocation = storageLocation;
+        this.expirationDate = expirationDate;
+    }
+
     public Long getId() {
         return id;
     }

--- a/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/fridgeitem/repository/FridgeItemRepository.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/fridgeitem/repository/FridgeItemRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 public interface FridgeItemRepository extends JpaRepository<FridgeItem, Long> {
 
     List<FridgeItem> findAllByUserId(Long userId);
+
+    List<FridgeItem> findAllByUserIdOrderByExpirationDateAscIdAsc(Long userId);
 }

--- a/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/fridgeitem/service/FridgeItemService.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/fridgeitem/service/FridgeItemService.java
@@ -1,0 +1,165 @@
+package com.example.foodaiplatformserver.fridgeitem.service;
+
+import com.example.foodaiplatformserver.common.exception.ForbiddenException;
+import com.example.foodaiplatformserver.common.exception.NotFoundException;
+import com.example.foodaiplatformserver.fridgeitem.dto.FridgeItemResponse;
+import com.example.foodaiplatformserver.fridgeitem.dto.FridgeItemSaveRequest;
+import com.example.foodaiplatformserver.fridgeitem.dto.FridgeItemSummaryItemResponse;
+import com.example.foodaiplatformserver.fridgeitem.dto.FridgeItemSummaryResponse;
+import com.example.foodaiplatformserver.fridgeitem.entity.FridgeItem;
+import com.example.foodaiplatformserver.fridgeitem.entity.ItemStatus;
+import com.example.foodaiplatformserver.fridgeitem.entity.StorageLocation;
+import com.example.foodaiplatformserver.fridgeitem.repository.FridgeItemRepository;
+import com.example.foodaiplatformserver.user.service.CurrentUserProvider;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+@Service
+@Transactional(readOnly = true)
+public class FridgeItemService {
+
+    private final FridgeItemRepository fridgeItemRepository;
+    private final CurrentUserProvider currentUserProvider;
+    private final FridgeItemStatusCalculator statusCalculator;
+
+    public FridgeItemService(FridgeItemRepository fridgeItemRepository,
+                             CurrentUserProvider currentUserProvider) {
+        this.fridgeItemRepository = fridgeItemRepository;
+        this.currentUserProvider = currentUserProvider;
+        this.statusCalculator = new FridgeItemStatusCalculator();
+    }
+
+    public FridgeItemSummaryResponse getSummary() {
+        List<FridgeItemResponse> responses = findCurrentUserItemResponses();
+        Map<String, Integer> locationStats = initializeLocationStats();
+
+        responses.forEach(item -> locationStats.compute(item.storageLocation(), (key, value) -> value + 1));
+
+        List<FridgeItemSummaryItemResponse> expiringSoonItems = responses.stream()
+                .filter(item -> "WARNING".equals(item.status()))
+                .map(this::toSummaryItem)
+                .toList();
+
+        List<FridgeItemSummaryItemResponse> expiredItems = responses.stream()
+                .filter(item -> "EXPIRED".equals(item.status()))
+                .map(this::toSummaryItem)
+                .toList();
+
+        return new FridgeItemSummaryResponse(
+                responses.size(),
+                expiringSoonItems.size(),
+                expiredItems.size(),
+                locationStats,
+                expiringSoonItems,
+                expiredItems
+        );
+    }
+
+    public List<FridgeItemResponse> getItems(String keyword,
+                                             String storageLocation,
+                                             String status) {
+        String normalizedKeyword = keyword == null ? null : normalize(keyword).toLowerCase(Locale.ROOT);
+
+        return findCurrentUserItemResponses().stream()
+                .filter(item -> matchesKeyword(item, normalizedKeyword))
+                .filter(item -> matchesStorageLocation(item, storageLocation))
+                .filter(item -> matchesStatus(item, status))
+                .toList();
+    }
+
+    @Transactional
+    public FridgeItemResponse create(FridgeItemSaveRequest request) {
+        Long userId = currentUserProvider.getCurrentUserId();
+        FridgeItem savedItem = fridgeItemRepository.save(new FridgeItem(
+                userId,
+                normalize(request.name()),
+                normalize(request.quantity()),
+                StorageLocation.valueOf(request.storageLocation()),
+                LocalDate.now(FridgeItemStatusCalculator.BUSINESS_ZONE),
+                request.expirationDate()
+        ));
+
+        return FridgeItemResponse.from(savedItem, statusCalculator);
+    }
+
+    @Transactional
+    public FridgeItemResponse update(Long itemId, FridgeItemSaveRequest request) {
+        FridgeItem fridgeItem = getOwnedFridgeItem(itemId);
+        fridgeItem.update(
+                normalize(request.name()),
+                normalize(request.quantity()),
+                StorageLocation.valueOf(request.storageLocation()),
+                request.expirationDate()
+        );
+
+        return FridgeItemResponse.from(fridgeItem, statusCalculator);
+    }
+
+    @Transactional
+    public void delete(Long itemId) {
+        fridgeItemRepository.delete(getOwnedFridgeItem(itemId));
+    }
+
+    private List<FridgeItemResponse> findCurrentUserItemResponses() {
+        return fridgeItemRepository.findAllByUserIdOrderByExpirationDateAscIdAsc(currentUserProvider.getCurrentUserId())
+                .stream()
+                .map(item -> FridgeItemResponse.from(item, statusCalculator))
+                .toList();
+    }
+
+    private FridgeItem getOwnedFridgeItem(Long itemId) {
+        Long userId = currentUserProvider.getCurrentUserId();
+        FridgeItem fridgeItem = fridgeItemRepository.findById(itemId)
+                .orElseThrow(() -> new NotFoundException("식재료를 찾을 수 없습니다."));
+
+        if (!fridgeItem.getUserId().equals(userId)) {
+            throw new ForbiddenException("다른 사용자의 식재료에는 접근할 수 없습니다.");
+        }
+
+        return fridgeItem;
+    }
+
+    private Map<String, Integer> initializeLocationStats() {
+        Map<String, Integer> locationStats = new LinkedHashMap<>();
+        Arrays.stream(StorageLocation.values())
+                .map(Enum::name)
+                .forEach(location -> locationStats.put(location, 0));
+        return locationStats;
+    }
+
+    private FridgeItemSummaryItemResponse toSummaryItem(FridgeItemResponse response) {
+        return new FridgeItemSummaryItemResponse(
+                response.itemId(),
+                response.name(),
+                response.dDay(),
+                response.statusText()
+        );
+    }
+
+    private boolean matchesKeyword(FridgeItemResponse item, String keyword) {
+        if (keyword == null || keyword.isBlank()) {
+            return true;
+        }
+
+        return item.name().toLowerCase(Locale.ROOT).contains(keyword);
+    }
+
+    private boolean matchesStorageLocation(FridgeItemResponse item, String storageLocation) {
+        return storageLocation == null || storageLocation.isBlank() || item.storageLocation().equals(storageLocation);
+    }
+
+    private boolean matchesStatus(FridgeItemResponse item, String status) {
+        return status == null || status.isBlank() || item.status().equals(status);
+    }
+
+    private String normalize(String value) {
+        return value.trim().replaceAll("\\s+", " ");
+    }
+}

--- a/food-ai-platform-server/src/test/java/com/example/foodaiplatformserver/fridgeitem/controller/FridgeItemControllerTest.java
+++ b/food-ai-platform-server/src/test/java/com/example/foodaiplatformserver/fridgeitem/controller/FridgeItemControllerTest.java
@@ -1,0 +1,334 @@
+package com.example.foodaiplatformserver.fridgeitem.controller;
+
+import com.example.foodaiplatformserver.auth.repository.UserAccountRepository;
+import com.example.foodaiplatformserver.fridgeitem.entity.FridgeItem;
+import com.example.foodaiplatformserver.fridgeitem.entity.StorageLocation;
+import com.example.foodaiplatformserver.fridgeitem.repository.FridgeItemRepository;
+import com.example.foodaiplatformserver.user.repository.UserPreferenceRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
+
+@SpringBootTest
+class FridgeItemControllerTest {
+
+    private static final ZoneId BUSINESS_ZONE = ZoneId.of("Asia/Seoul");
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserAccountRepository userAccountRepository;
+
+    @Autowired
+    private UserPreferenceRepository userPreferenceRepository;
+
+    @Autowired
+    private FridgeItemRepository fridgeItemRepository;
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @BeforeEach
+    void setUp() {
+        fridgeItemRepository.deleteAll();
+        userPreferenceRepository.deleteAll();
+        userAccountRepository.deleteAll();
+        mockMvc = webAppContextSetup(webApplicationContext).build();
+    }
+
+    @DisplayName("냉장고 현황 요약을 반환한다")
+    @Test
+    void returnsSummary() throws Exception {
+        AuthSession user = signupAndLogin("summary@example.com");
+
+        saveFridgeItem(user.userId(), "당근", "1개", StorageLocation.REFRIGERATED, 1);
+        saveFridgeItem(user.userId(), "만두", "10개", StorageLocation.FROZEN, -2);
+        saveFridgeItem(user.userId(), "양파", "2개", StorageLocation.ROOM_TEMP, 10);
+
+        mockMvc.perform(get("/fridge-items/summary")
+                        .header("Authorization", "Bearer " + user.accessToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.total_count").value(3))
+                .andExpect(jsonPath("$.expiring_soon_count").value(1))
+                .andExpect(jsonPath("$.expired_count").value(1))
+                .andExpect(jsonPath("$.location_stats.REFRIGERATED").value(1))
+                .andExpect(jsonPath("$.location_stats.FROZEN").value(1))
+                .andExpect(jsonPath("$.location_stats.ROOM_TEMP").value(1))
+                .andExpect(jsonPath("$.expiring_soon_items", hasSize(1)))
+                .andExpect(jsonPath("$.expired_items", hasSize(1)));
+    }
+
+    @DisplayName("로그인 사용자의 식재료 전체 목록을 유통기한 임박순으로 조회한다")
+    @Test
+    void getFridgeItemsOrderedByExpirationDate() throws Exception {
+        AuthSession user = signupAndLogin("user@example.com");
+        AuthSession otherUser = signupAndLogin("other@example.com");
+
+        saveFridgeItem(user.userId(), "당근", "1개", StorageLocation.REFRIGERATED, 7);
+        saveFridgeItem(user.userId(), "대파", "100g", StorageLocation.REFRIGERATED, 1);
+        saveFridgeItem(otherUser.userId(), "외부데이터", "1개", StorageLocation.ROOM_TEMP, 0);
+
+        mockMvc.perform(get("/fridge-items")
+                        .header("Authorization", "Bearer " + user.accessToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[0].name").value("대파"))
+                .andExpect(jsonPath("$[0].status").value("WARNING"))
+                .andExpect(jsonPath("$[0].d_day").value(1))
+                .andExpect(jsonPath("$[1].name").value("당근"));
+    }
+
+    @DisplayName("검색어, 보관 위치, 상태 필터를 조합해서 조회할 수 있다")
+    @Test
+    void getFridgeItemsWithCombinedFilters() throws Exception {
+        AuthSession user = signupAndLogin("filter@example.com");
+
+        saveFridgeItem(user.userId(), "대파", "100g", StorageLocation.REFRIGERATED, 2);
+        saveFridgeItem(user.userId(), "대패삼겹살", "300g", StorageLocation.FROZEN, 10);
+        saveFridgeItem(user.userId(), "대추", "10개", StorageLocation.REFRIGERATED, -1);
+
+        mockMvc.perform(get("/fridge-items")
+                        .header("Authorization", "Bearer " + user.accessToken())
+                        .queryParam("keyword", "대")
+                        .queryParam("storage_location", "REFRIGERATED")
+                        .queryParam("status", "WARNING"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].name").value("대파"))
+                .andExpect(jsonPath("$[0].storage_location").value("REFRIGERATED"))
+                .andExpect(jsonPath("$[0].status").value("WARNING"));
+    }
+
+    @DisplayName("식재료 등록에 성공하면 201과 생성된 식재료를 반환한다")
+    @Test
+    void createFridgeItem() throws Exception {
+        AuthSession user = signupAndLogin("create@example.com");
+        LocalDate expirationDate = LocalDate.now(BUSINESS_ZONE).plusDays(13);
+
+        mockMvc.perform(post("/fridge-items")
+                        .header("Authorization", "Bearer " + user.accessToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name": "우유",
+                                  "quantity": "500ml",
+                                  "storage_location": "REFRIGERATED",
+                                  "expiration_date": "%s"
+                                }
+                                """.formatted(expirationDate)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.item_id").isNumber())
+                .andExpect(jsonPath("$.name").value("우유"))
+                .andExpect(jsonPath("$.quantity").value("500ml"))
+                .andExpect(jsonPath("$.storage_location").value("REFRIGERATED"))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.d_day").value(13))
+                .andExpect(jsonPath("$.status_text").value("D-13"));
+    }
+
+    @DisplayName("식재료 등록 시 길이 제한을 넘으면 400을 반환한다")
+    @Test
+    void createFridgeItemRejectsTooLongFields() throws Exception {
+        AuthSession user = signupAndLogin("length@example.com");
+        String longName = "가".repeat(101);
+        String longQuantity = "1".repeat(51);
+
+        mockMvc.perform(post("/fridge-items")
+                        .header("Authorization", "Bearer " + user.accessToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name": "%s",
+                                  "quantity": "%s",
+                                  "storage_location": "REFRIGERATED",
+                                  "expiration_date": "%s"
+                                }
+                                """.formatted(
+                                longName,
+                                longQuantity,
+                                LocalDate.now(BUSINESS_ZONE).plusDays(13)
+                        )))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_REQUEST"))
+                .andExpect(jsonPath("$.details[*].field").value(org.hamcrest.Matchers.hasItems("name", "quantity")));
+    }
+
+    @DisplayName("본인 식재료 수정에 성공하면 200과 수정된 식재료를 반환한다")
+    @Test
+    void updateOwnedFridgeItem() throws Exception {
+        AuthSession user = signupAndLogin("update@example.com");
+        FridgeItem fridgeItem = saveFridgeItem(user.userId(), "우유", "500ml", StorageLocation.REFRIGERATED, 5);
+        LocalDate updatedExpirationDate = LocalDate.now(BUSINESS_ZONE).plusDays(14);
+
+        mockMvc.perform(put("/fridge-items/{itemId}", fridgeItem.getId())
+                        .header("Authorization", "Bearer " + user.accessToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name": "저지방 우유",
+                                  "quantity": "450ml",
+                                  "storage_location": "REFRIGERATED",
+                                  "expiration_date": "%s"
+                                }
+                                """.formatted(updatedExpirationDate)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.item_id").value(fridgeItem.getId()))
+                .andExpect(jsonPath("$.name").value("저지방 우유"))
+                .andExpect(jsonPath("$.quantity").value("450ml"))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.d_day").value(14))
+                .andExpect(jsonPath("$.status_text").value("D-14"));
+    }
+
+    @DisplayName("타인의 식재료 수정은 403을 반환한다")
+    @Test
+    void updateOtherUsersFridgeItemFails() throws Exception {
+        AuthSession user = signupAndLogin("user1@example.com");
+        AuthSession otherUser = signupAndLogin("user2@example.com");
+        FridgeItem fridgeItem = saveFridgeItem(otherUser.userId(), "사과", "2개", StorageLocation.ROOM_TEMP, 2);
+
+        mockMvc.perform(put("/fridge-items/{itemId}", fridgeItem.getId())
+                        .header("Authorization", "Bearer " + user.accessToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name": "청사과",
+                                  "quantity": "3개",
+                                  "storage_location": "ROOM_TEMP",
+                                  "expiration_date": "%s"
+                                }
+                                """.formatted(LocalDate.now(BUSINESS_ZONE).plusDays(3))))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("FORBIDDEN"));
+    }
+
+    @DisplayName("존재하지 않는 식재료 수정은 404를 반환한다")
+    @Test
+    void updateMissingFridgeItemFails() throws Exception {
+        AuthSession user = signupAndLogin("missing-update@example.com");
+
+        mockMvc.perform(put("/fridge-items/{itemId}", 9999L)
+                        .header("Authorization", "Bearer " + user.accessToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name": "우유",
+                                  "quantity": "500ml",
+                                  "storage_location": "REFRIGERATED",
+                                  "expiration_date": "%s"
+                                }
+                                """.formatted(LocalDate.now(BUSINESS_ZONE).plusDays(5))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+    }
+
+    @DisplayName("본인 식재료 삭제에 성공하면 204를 반환한다")
+    @Test
+    void deleteOwnedFridgeItem() throws Exception {
+        AuthSession user = signupAndLogin("delete@example.com");
+        FridgeItem fridgeItem = saveFridgeItem(user.userId(), "우유", "500ml", StorageLocation.REFRIGERATED, 5);
+
+        mockMvc.perform(delete("/fridge-items/{itemId}", fridgeItem.getId())
+                        .header("Authorization", "Bearer " + user.accessToken()))
+                .andExpect(status().isNoContent());
+    }
+
+    @DisplayName("타인의 식재료 삭제는 403을 반환한다")
+    @Test
+    void deleteOtherUsersFridgeItemFails() throws Exception {
+        AuthSession user = signupAndLogin("delete-user1@example.com");
+        AuthSession otherUser = signupAndLogin("delete-user2@example.com");
+        FridgeItem fridgeItem = saveFridgeItem(otherUser.userId(), "사과", "2개", StorageLocation.ROOM_TEMP, 2);
+
+        mockMvc.perform(delete("/fridge-items/{itemId}", fridgeItem.getId())
+                        .header("Authorization", "Bearer " + user.accessToken()))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("FORBIDDEN"));
+    }
+
+    @DisplayName("존재하지 않는 식재료 삭제는 404를 반환한다")
+    @Test
+    void deleteMissingFridgeItemFails() throws Exception {
+        AuthSession user = signupAndLogin("missing-delete@example.com");
+
+        mockMvc.perform(delete("/fridge-items/{itemId}", 9999L)
+                        .header("Authorization", "Bearer " + user.accessToken()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+    }
+
+    private FridgeItem saveFridgeItem(Long userId,
+                                      String name,
+                                      String quantity,
+                                      StorageLocation storageLocation,
+                                      int expirationOffsetDays) {
+        return fridgeItemRepository.save(new FridgeItem(
+                userId,
+                name,
+                quantity,
+                storageLocation,
+                LocalDate.of(2026, 5, 1),
+                LocalDate.now(BUSINESS_ZONE).plusDays(expirationOffsetDays)
+        ));
+    }
+
+    private AuthSession signupAndLogin(String email) throws Exception {
+        mockMvc.perform(post("/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "username": "%s",
+                                  "email": "%s",
+                                  "password": "password123!"
+                                }
+                                """.formatted(email, email)))
+                .andExpect(status().isCreated());
+
+        String loginResponse = mockMvc.perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "email": "%s",
+                                  "password": "password123!"
+                                }
+                                """.formatted(email)))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        JsonNode jsonNode = objectMapper.readTree(loginResponse);
+        return new AuthSession(
+                jsonNode.get("access_token").asText(),
+                jsonNode.get("user").get("user_id").asLong()
+        );
+    }
+
+    private record AuthSession(
+            String accessToken,
+            Long userId
+    ) {
+    }
+}


### PR DESCRIPTION
## Summary
- `fridge-items` 백엔드를 정상 경로로 복구해 목록, 요약, 등록, 수정, 삭제 API를 되살렸습니다.
- 식재료 응답 DTO와 요약 응답 DTO를 추가하고, 식재료 수정용 도메인 업데이트 로직 및 조회 정렬 레포지토리 메서드를 보강했습니다.
- `fridge-items` 통합 테스트를 추가해 요약, 필터 조회, CRUD, 권한/404/검증 실패까지 검증합니다.

## Testing
- `./gradlew test` 통과 확인 완료