### PR TITLE
API 명세 정합성 개선 반영

### DIFF
--- a/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/common/handler/GlobalExceptionHandler.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/common/handler/GlobalExceptionHandler.java
@@ -34,7 +34,7 @@ public class GlobalExceptionHandler {
                 .getFieldErrors()
                 .stream()
                 .sorted(Comparator.comparing(FieldError::getField))
-                .map(fieldError -> new ApiErrorDetail(fieldError.getField(), fieldError.getDefaultMessage()))
+                .map(fieldError -> new ApiErrorDetail(toSnakeCaseField(fieldError.getField()), fieldError.getDefaultMessage()))
                 .toList();
 
         return badRequest(ApiErrorCode.INVALID_REQUEST.getMessage(), details);
@@ -44,7 +44,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiErrorResponse> handleConstraintViolation(ConstraintViolationException exception) {
         List<ApiErrorDetail> details = exception.getConstraintViolations()
                 .stream()
-                .map(violation -> new ApiErrorDetail(violation.getPropertyPath().toString(), violation.getMessage()))
+                .map(violation -> new ApiErrorDetail(toSnakeCaseField(violation.getPropertyPath().toString()), violation.getMessage()))
                 .toList();
 
         return badRequest(ApiErrorCode.INVALID_REQUEST.getMessage(), details);
@@ -71,5 +71,27 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity.status(errorCode.getHttpStatus())
                 .body(ApiErrorResponse.of(errorCode, message, details));
+    }
+
+    private String toSnakeCaseField(String rawField) {
+        String field = rawField;
+        int lastDotIndex = field.lastIndexOf('.');
+        if (lastDotIndex >= 0) {
+            field = field.substring(lastDotIndex + 1);
+        }
+
+        StringBuilder snakeCase = new StringBuilder();
+        for (int index = 0; index < field.length(); index++) {
+            char current = field.charAt(index);
+            if (Character.isUpperCase(current)) {
+                if (!snakeCase.isEmpty()) {
+                    snakeCase.append('_');
+                }
+                snakeCase.append(Character.toLowerCase(current));
+                continue;
+            }
+            snakeCase.append(current);
+        }
+        return snakeCase.toString();
     }
 }

--- a/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/user/dto/UserPreferenceResponse.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/user/dto/UserPreferenceResponse.java
@@ -2,6 +2,7 @@ package com.example.foodaiplatformserver.user.dto;
 
 import com.example.foodaiplatformserver.user.entity.DifficultyPreference;
 import com.example.foodaiplatformserver.user.entity.FavoriteCuisine;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -9,6 +10,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record UserPreferenceResponse(
         @JsonProperty("user_id")
@@ -18,7 +20,7 @@ public record UserPreferenceResponse(
         @JsonProperty("difficulty_preference")
         DifficultyPreference difficultyPreference,
         @JsonProperty("quick_meal_preferred")
-        boolean quickMealPreferred,
+        Boolean quickMealPreferred,
         @JsonProperty("updated_at")
         LocalDateTime updatedAt
 ) {

--- a/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/user/service/UserPreferenceService.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/user/service/UserPreferenceService.java
@@ -53,7 +53,7 @@ public class UserPreferenceService {
 
         return userPreferenceRepository.findByUserId(userId)
                 .map(this::toResponse)
-                .orElseThrow(() -> new UserPreferenceNotFoundException(userId));
+                .orElseGet(() -> emptyResponse(userId));
     }
 
     private UserPreferenceResponse toResponse(UserPreference userPreference) {
@@ -63,6 +63,16 @@ public class UserPreferenceService {
                 userPreference.getDifficultyPreference(),
                 userPreference.isQuickMealPreferred(),
                 userPreference.getUpdatedAt()
+        );
+    }
+
+    private UserPreferenceResponse emptyResponse(Long userId) {
+        return new UserPreferenceResponse(
+                userId,
+                List.of(),
+                null,
+                null,
+                null
         );
     }
 

--- a/food-ai-platform-server/src/main/resources/application.properties
+++ b/food-ai-platform-server/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 spring.application.name=food-ai-platform-server
+server.servlet.context-path=/api/v1
 spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:mysql://localhost:3306/food_ai_platform?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8}
 spring.datasource.username=${SPRING_DATASOURCE_USERNAME:food_ai_platform}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:food_ai_platform}

--- a/food-ai-platform-server/src/test/java/com/example/foodaiplatformserver/auth/controller/ApiVersionContextPathIntegrationTest.java
+++ b/food-ai-platform-server/src/test/java/com/example/foodaiplatformserver/auth/controller/ApiVersionContextPathIntegrationTest.java
@@ -1,0 +1,50 @@
+package com.example.foodaiplatformserver.auth.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(properties = "server.servlet.context-path=/api/v1")
+class ApiVersionContextPathIntegrationTest {
+
+    private final MockMvc mockMvc;
+
+    ApiVersionContextPathIntegrationTest(WebApplicationContext webApplicationContext) {
+        this.mockMvc = webAppContextSetup(webApplicationContext).build();
+    }
+
+    @DisplayName("회원가입 API는 /api/v1 base path 아래에서 동작한다")
+    @Test
+    void signupWorksUnderApiVersionContextPath() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/signup")
+                        .contextPath("/api/v1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "username": "홍길동",
+                                  "email": "versioned@example.com",
+                                  "password": "password123!"
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.user.email").value("versioned@example.com"));
+    }
+
+    @DisplayName("보호된 API는 /api/v1 base path 아래에서 인증을 요구한다")
+    @Test
+    void protectedApiRequiresAuthUnderApiVersionContextPath() throws Exception {
+        mockMvc.perform(get("/api/v1/users/me/preferences")
+                        .contextPath("/api/v1"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("UNAUTHORIZED"));
+    }
+}

--- a/food-ai-platform-server/src/test/java/com/example/foodaiplatformserver/user/controller/UserPreferenceControllerTest.java
+++ b/food-ai-platform-server/src/test/java/com/example/foodaiplatformserver/user/controller/UserPreferenceControllerTest.java
@@ -141,8 +141,23 @@ class UserPreferenceControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("INVALID_REQUEST"))
                 .andExpect(jsonPath("$.details", hasSize(2)))
-                .andExpect(jsonPath("$.details[0].field").value("difficultyPreference"))
-                .andExpect(jsonPath("$.details[1].field").value("favoriteCuisines"));
+                .andExpect(jsonPath("$.details[0].field").value("difficulty_preference"))
+                .andExpect(jsonPath("$.details[1].field").value("favorite_cuisines"));
+    }
+
+    @DisplayName("선호 정보를 저장하지 않은 사용자도 빈 응답으로 조회할 수 있다")
+    @Test
+    void returnsEmptyPreferenceWhenPreferenceDoesNotExist() throws Exception {
+        AuthSession authSession = signupAndLogin();
+
+        mockMvc.perform(get("/users/me/preferences")
+                        .header("Authorization", "Bearer " + authSession.accessToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.user_id").value(authSession.userId()))
+                .andExpect(jsonPath("$.favorite_cuisines", hasSize(0)))
+                .andExpect(jsonPath("$.difficulty_preference").doesNotExist())
+                .andExpect(jsonPath("$.quick_meal_preferred").doesNotExist())
+                .andExpect(jsonPath("$.updated_at").doesNotExist());
     }
 
     @DisplayName("토큰 없이 선호 조회를 호출하면 인증 에러를 반환한다")

--- a/food-ai-platform-server/src/test/java/com/example/foodaiplatformserver/userrecipe/controller/UserRecipeControllerTest.java
+++ b/food-ai-platform-server/src/test/java/com/example/foodaiplatformserver/userrecipe/controller/UserRecipeControllerTest.java
@@ -142,7 +142,7 @@ class UserRecipeControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("INVALID_REQUEST"))
                 .andExpect(jsonPath("$.details[*].field", hasItem("category")))
-                .andExpect(jsonPath("$.details[*].field", hasItem("recipeName")));
+                .andExpect(jsonPath("$.details[*].field", hasItem("recipe_name")));
     }
 
     private void createHistory(String accessToken, int recipeId, String recipeName, String category) throws Exception {

--- a/food-ai-platform-server/src/test/resources/application.properties
+++ b/food-ai-platform-server/src/test/resources/application.properties
@@ -1,4 +1,5 @@
 spring.datasource.url=jdbc:h2:mem:food_ai_platform;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+server.servlet.context-path=
 spring.datasource.username=sa
 spring.datasource.password=
 spring.datasource.driver-class-name=org.h2.Driver


### PR DESCRIPTION
## Summary
- `API_SPEC.md` 기준으로 백엔드 응답 계약을 정리했습니다.
- `/api/v1` 컨텍스트 경로를 적용하고, 해당 경로 동작을 검증하는 통합 테스트를 추가했습니다.
- 사용자 취향 조회는 미저장 상태에서도 `200 OK` 로 빈 응답을 반환하도록 맞췄습니다.
- 검증 오류의 `details.field` 값을 `snake_case` 로 통일했습니다.

## Testing
- `./gradlew test` 통과
- 신규/수정 테스트로 API 버전 경로, 선호 조회 빈 응답, 검증 필드명 포맷을 검증했습니다.