### PR TITLE
127.0.0.1:5500 CORS 허용 및 통합 테스트 추가

### DIFF
--- a/food-ai-platform-server/src/main/resources/application.properties
+++ b/food-ai-platform-server/src/main/resources/application.properties
@@ -11,7 +11,7 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 
 app.jwt.secret=${APP_JWT_SECRET:food-ai-platform-jwt-secret-key-for-local-development-2026}
 app.jwt.expiration-seconds=${APP_JWT_EXPIRATION_SECONDS:3600}
-app.cors.allowed-origins=${APP_CORS_ALLOWED_ORIGINS:http://localhost:5500,http://localhost:3000,http://localhost:5173}
+app.cors.allowed-origins=${APP_CORS_ALLOWED_ORIGINS:http://localhost:5500,http://127.0.0.1:5500,http://localhost:3000,http://localhost:5173}
 app.cors.allowed-origin-patterns=${APP_CORS_ALLOWED_ORIGIN_PATTERNS:https://*.with-momo.com}
 app.recipe.recommendation.provider=${APP_RECIPE_RECOMMENDATION_PROVIDER:auto}
 app.gemini.api-key=${APP_GEMINI_API_KEY:}

--- a/food-ai-platform-server/src/test/java/com/example/foodaiplatformserver/auth/controller/CorsIntegrationTest.java
+++ b/food-ai-platform-server/src/test/java/com/example/foodaiplatformserver/auth/controller/CorsIntegrationTest.java
@@ -16,20 +16,32 @@ import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppC
 @SpringBootTest
 class CorsIntegrationTest {
 
+    private static final String PREFERENCES_ENDPOINT = "/users/me/preferences";
+
     @Autowired
     private WebApplicationContext webApplicationContext;
 
     @DisplayName("프론트 origin의 preflight 요청은 인증 없이 허용된다")
     @Test
     void allowsPreflightFromFrontendOrigin() throws Exception {
+        assertPreflightAllowed("http://localhost:5500");
+    }
+
+    @DisplayName("127.0.0.1 origin의 preflight 요청은 인증 없이 허용된다")
+    @Test
+    void allowsPreflightFromLoopbackOrigin() throws Exception {
+        assertPreflightAllowed("http://127.0.0.1:5500");
+    }
+
+    private void assertPreflightAllowed(String origin) throws Exception {
         MockMvc mockMvc = webAppContextSetup(webApplicationContext).build();
 
-        mockMvc.perform(options("/users/me/preferences")
-                        .header(HttpHeaders.ORIGIN, "http://localhost:5500")
+        mockMvc.perform(options(PREFERENCES_ENDPOINT)
+                        .header(HttpHeaders.ORIGIN, origin)
                         .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "PUT")
                         .header(HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS, "Authorization, Content-Type"))
                 .andExpect(status().isOk())
-                .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "http://localhost:5500"))
+                .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, origin))
                 .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true"));
     }
 }

--- a/food-ai-platform-server/src/test/resources/application.properties
+++ b/food-ai-platform-server/src/test/resources/application.properties
@@ -10,6 +10,6 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
 
 app.jwt.secret=test-jwt-secret-key
 app.jwt.expiration-seconds=3600
-app.cors.allowed-origins=http://localhost:5500,http://localhost:3000,http://localhost:5173
+app.cors.allowed-origins=http://localhost:5500,http://127.0.0.1:5500,http://localhost:3000,http://localhost:5173
 app.cors.allowed-origin-patterns=https://*.with-momo.com
 app.recipe.recommendation.provider=mock


### PR DESCRIPTION
## Summary
- 로컬 Live Server에서 사용하는 `http://127.0.0.1:5500`을 CORS 허용 목록에 추가했습니다.
- 테스트 설정에도 동일한 Origin을 반영해 메인/테스트 환경을 맞췄습니다.
- `localhost`와 `127.0.0.1` 둘 다 preflight가 통과하는 통합 테스트를 추가했습니다.

## Testing
- 기존 CORS 통합 테스트를 확장해 `http://localhost:5500`과 `http://127.0.0.1:5500` 모두 검증했습니다.
- 로컬에서 관련 Gradle 테스트가 통과하는 것을 확인했습니다.