### PR TITLE
fix: align signup user mapping with existing schema

### DIFF
--- a/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/auth/entity/UserAccount.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/auth/entity/UserAccount.java
@@ -13,9 +13,10 @@ public class UserAccount {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
     private Long id;
 
-    @Column(nullable = false, length = 100)
+    @Column(nullable = false, length = 50)
     private String username;
 
     @Column(nullable = false, unique = true, length = 255)


### PR DESCRIPTION
# 문제

회원가입 API(`POST /api/v1/auth/signup`) 호출 시 브라우저에서는 "서버 내부 문제"로 보였고, 실제 배포 API 응답도 `500 INTERNAL_SERVER_ERROR`가 발생하고 있었다.

확인 결과 CORS 문제는 아니었다.

- `OPTIONS /api/v1/auth/signup` : `200 OK`
- CORS 헤더 정상 반환
- `POST /api/v1/auth/signup` : `500 INTERNAL_SERVER_ERROR`

즉, 프론트 요청 자체가 막힌 것이 아니라 백엔드가 회원가입 저장 처리 중 내부 오류를 내고 있는 상태였다.

원인으로 가장 유력했던 부분은 `users` 테이블의 기존 운영 스키마와 현재 `UserAccount` 엔티티 매핑 불일치였다.

- 기존 운영 스키마 기준 PK 컬럼명: `user_id`
- 현재 엔티티 매핑 기준 PK 컬럼명: `id`
- 기존 스키마의 `username` 길이와 현재 엔티티 길이 설정도 차이가 있었다

이 불일치 때문에 회원가입 시 JPA가 기존 `users` 테이블을 잘못 해석하거나 저장 과정에서 오류를 일으켜 `500`이 발생했을 가능성이 높았다.

# 수정 내용

`food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/auth/entity/UserAccount.java`에서 운영 DB 스키마에 맞도록 엔티티 매핑을 수정했다.

## 변경 사항

1. `id` 필드에 PK 컬럼명 명시
- `@Column(name = "user_id")` 추가

2. `username` 길이 조정
- `length = 100` -> `length = 50`

## 기대 효과

- 기존 `users` 테이블 스키마와 JPA 엔티티 매핑 일치
- 회원가입 저장 시 컬럼 매핑 오류 가능성 감소
- `POST /api/v1/auth/signup` 호출 시 발생하던 `500 INTERNAL_SERVER_ERROR` 해결 기대