### PR TITLE
Bug/signup false duplicate email

### DIFF
--- a/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/auth/service/AuthService.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/auth/service/AuthService.java
@@ -54,7 +54,10 @@ public class AuthService {
                 UserAccount saved = userAccountRepository.saveAndFlush(userAccount);
                 return new AuthSignupResponse("회원가입이 완료되었습니다.", toUserResponse(saved));
             } catch (DataIntegrityViolationException exception) {
-                throw new DuplicateEmailException(request.email());
+                if (userAccountRepository.existsByEmail(request.email())) {
+                    throw new DuplicateEmailException(request.email());
+                }
+                throw exception;
             }
         });
     }

--- a/food-ai-platform-server/src/test/java/com/example/foodaiplatformserver/auth/service/AuthServiceTest.java
+++ b/food-ai-platform-server/src/test/java/com/example/foodaiplatformserver/auth/service/AuthServiceTest.java
@@ -31,12 +31,25 @@ class AuthServiceTest {
     @Test
     void convertsDuplicateEmailConstraintToConflict() {
         AuthSignupRequest request = new AuthSignupRequest("홍길동", "user@example.com", "password123!");
-        when(userAccountRepository.existsByEmail(request.email())).thenReturn(false);
+        when(userAccountRepository.existsByEmail(request.email())).thenReturn(false, true);
         when(userAccountRepository.saveAndFlush(any()))
                 .thenThrow(new DataIntegrityViolationException("duplicate email"));
 
         assertThatThrownBy(() -> authService.signup(request))
                 .isInstanceOf(DuplicateEmailException.class)
                 .hasMessageContaining("이미 가입된 이메일입니다.");
+    }
+
+    @DisplayName("중복 이메일이 아닌 저장 오류는 그대로 전파한다")
+    @Test
+    void rethrowsNonDuplicateDataIntegrityViolation() {
+        AuthSignupRequest request = new AuthSignupRequest("홍길동", "user@example.com", "password123!");
+        DataIntegrityViolationException exception = new DataIntegrityViolationException("schema mismatch");
+
+        when(userAccountRepository.existsByEmail(request.email())).thenReturn(false, false);
+        when(userAccountRepository.saveAndFlush(any())).thenThrow(exception);
+
+        assertThatThrownBy(() -> authService.signup(request))
+                .isSameAs(exception);
     }
 }


### PR DESCRIPTION
# 브랜치

- `bug/signup-false-duplicate-email`

# 문제

회원가입 시 콘솔에서 `409 CONFLICT`가 발생했고, 실제로는 아직 가입하지 않은 이메일인데도
`이미 가입된 이메일입니다.` 라는 메시지가 내려오고 있었다.

원인은 `AuthService`의 회원가입 처리 로직에서
`DataIntegrityViolationException`이 발생하면 원인을 구분하지 않고
무조건 `DuplicateEmailException`으로 변환하고 있었기 때문이다.

즉, 실제 중복 이메일이 아닌 경우에도

- DB 스키마 불일치
- 컬럼 매핑 문제
- 기타 저장 실패

같은 내부 저장 오류가 전부 `409 중복 이메일`처럼 보이게 되는 문제가 있었다.

# 수정 내용

`food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/auth/service/AuthService.java`

회원가입 저장 중 `DataIntegrityViolationException`이 발생했을 때,
즉시 중복 이메일로 변환하지 않고 실제로 해당 이메일이 존재하는지 다시 확인하도록 수정했다.

## 변경 방식

- 저장 실패 후 `userAccountRepository.existsByEmail(request.email())` 재확인
- 실제로 이메일이 존재하면 `DuplicateEmailException` 발생
- 존재하지 않으면 원래 예외를 그대로 전파

# 기대 효과

- 진짜 중복 이메일만 `409 CONFLICT`로 응답
- 스키마 문제나 기타 저장 오류를 중복 이메일로 잘못 숨기지 않음
- 회원가입 실패 원인을 더 정확하게 확인 가능

# 테스트 보강

`food-ai-platform-server/src/test/java/com/example/foodaiplatformserver/auth/service/AuthServiceTest.java`

다음 케이스를 검증하도록 테스트를 추가했다.

1. 유니크 제약 충돌 후 실제 이메일이 존재하면 `DuplicateEmailException`으로 변환되는지
2. 중복 이메일이 아닌 저장 오류는 그대로 전파되는지

# 커밋

- `8bceb7a` `fix: avoid masking signup persistence errors as duplicates`
- `2d81304` `test: cover signup duplicate-email error handling`