### PR TITLE
Bug/users table schema mismatch guard

### DIFF
--- a/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/auth/config/UsersTableSchemaValidator.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/auth/config/UsersTableSchemaValidator.java
@@ -1,0 +1,123 @@
+package com.example.foodaiplatformserver.auth.config;
+
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+
+@Component
+public class UsersTableSchemaValidator implements ApplicationRunner {
+
+    private static final String USERS_TABLE = "users";
+
+    private final DataSource dataSource;
+
+    public UsersTableSchemaValidator(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        try (Connection connection = dataSource.getConnection()) {
+            DatabaseMetaData metaData = connection.getMetaData();
+            Optional<String> validationError = inspectUsersTable(metaData, connection.getCatalog(), connection.getSchema());
+            validationError.ifPresent(message -> {
+                throw new IllegalStateException(message);
+            });
+        } catch (SQLException exception) {
+            throw new IllegalStateException("users 테이블 스키마 검증 중 오류가 발생했습니다.", exception);
+        }
+    }
+
+    Optional<String> inspectUsersTable(DatabaseMetaData metaData, String catalog, String schema) throws SQLException {
+        if (!tableExists(metaData, catalog, schema, USERS_TABLE)) {
+            return Optional.empty();
+        }
+
+        Set<String> columns = readColumns(metaData, catalog, schema, USERS_TABLE);
+        Set<String> primaryKeys = readPrimaryKeys(metaData, catalog, schema, USERS_TABLE);
+        return validateUsersTableSchema(columns, primaryKeys);
+    }
+
+    static Optional<String> validateUsersTableSchema(Set<String> columns, Set<String> primaryKeys) {
+        Set<String> normalizedColumns = normalize(columns);
+        Set<String> normalizedPrimaryKeys = normalize(primaryKeys);
+
+        if (normalizedPrimaryKeys.contains("id") && !normalizedPrimaryKeys.contains("user_id")) {
+            return Optional.of("""
+                    레거시 users 테이블 스키마가 감지되었습니다. 현재 애플리케이션은 users.user_id PK를 기대하지만, DB에는 기존 id PK가 남아 있습니다.
+                    기존 users 테이블을 정리한 뒤 서버를 다시 띄워 엔티티 기준으로 재생성해주세요.
+                    """.strip());
+        }
+
+        if (!normalizedColumns.contains("user_id")) {
+            return Optional.of("users 테이블에 user_id 컬럼이 없습니다. 현재 엔티티 스키마와 DB 구조를 확인해주세요.");
+        }
+
+        if (!normalizedPrimaryKeys.contains("user_id")) {
+            return Optional.of("users 테이블의 PK가 user_id가 아닙니다. 현재 엔티티 스키마와 DB 구조를 확인해주세요.");
+        }
+
+        return Optional.empty();
+    }
+
+    private boolean tableExists(DatabaseMetaData metaData, String catalog, String schema, String tableName) throws SQLException {
+        try (ResultSet resultSet = metaData.getTables(catalog, schema, null, new String[]{"TABLE"})) {
+            while (resultSet.next()) {
+                String currentTableName = resultSet.getString("TABLE_NAME");
+                if (tableName.equalsIgnoreCase(currentTableName)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private Set<String> readColumns(DatabaseMetaData metaData, String catalog, String schema, String tableName) throws SQLException {
+        Set<String> columns = new LinkedHashSet<>();
+        try (ResultSet resultSet = metaData.getColumns(catalog, schema, null, null)) {
+            while (resultSet.next()) {
+                String currentTableName = resultSet.getString("TABLE_NAME");
+                if (tableName.equalsIgnoreCase(currentTableName)) {
+                    columns.add(resultSet.getString("COLUMN_NAME"));
+                }
+            }
+        }
+        return columns;
+    }
+
+    private Set<String> readPrimaryKeys(DatabaseMetaData metaData, String catalog, String schema, String tableName) throws SQLException {
+        Set<String> primaryKeys = new LinkedHashSet<>();
+        try (ResultSet resultSet = metaData.getPrimaryKeys(catalog, schema, tableName)) {
+            while (resultSet.next()) {
+                primaryKeys.add(resultSet.getString("COLUMN_NAME"));
+            }
+        }
+
+        if (!primaryKeys.isEmpty()) {
+            return primaryKeys;
+        }
+
+        try (ResultSet resultSet = metaData.getPrimaryKeys(catalog, schema, tableName.toUpperCase(Locale.ROOT))) {
+            while (resultSet.next()) {
+                primaryKeys.add(resultSet.getString("COLUMN_NAME"));
+            }
+        }
+        return primaryKeys;
+    }
+
+    private static Set<String> normalize(Set<String> values) {
+        return values.stream()
+                .map(value -> value.toLowerCase(Locale.ROOT))
+                .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
+    }
+}

--- a/food-ai-platform-server/src/test/java/com/example/foodaiplatformserver/auth/config/UsersTableSchemaValidatorTest.java
+++ b/food-ai-platform-server/src/test/java/com/example/foodaiplatformserver/auth/config/UsersTableSchemaValidatorTest.java
@@ -1,0 +1,47 @@
+package com.example.foodaiplatformserver.auth.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UsersTableSchemaValidatorTest {
+
+    @DisplayName("users 테이블이 예전 id PK를 쓰면 명확한 스키마 오류를 반환한다")
+    @Test
+    void returnsHelpfulMessageForLegacyPrimaryKey() {
+        Optional<String> validationError = UsersTableSchemaValidator.validateUsersTableSchema(
+                Set.of("id", "username", "email", "password"),
+                Set.of("id")
+        );
+
+        assertThat(validationError).isPresent();
+        assertThat(validationError.get()).contains("users.user_id PK");
+    }
+
+    @DisplayName("users 테이블에 user_id PK가 있으면 정상 스키마로 판단한다")
+    @Test
+    void acceptsExpectedUsersSchema() {
+        Optional<String> validationError = UsersTableSchemaValidator.validateUsersTableSchema(
+                Set.of("user_id", "username", "email", "password"),
+                Set.of("user_id")
+        );
+
+        assertThat(validationError).isEmpty();
+    }
+
+    @DisplayName("user_id 컬럼은 있지만 PK가 아니면 오류를 반환한다")
+    @Test
+    void returnsErrorWhenUserIdIsNotPrimaryKey() {
+        Optional<String> validationError = UsersTableSchemaValidator.validateUsersTableSchema(
+                Set.of("user_id", "username", "email", "password"),
+                Set.of("email")
+        );
+
+        assertThat(validationError).isPresent();
+        assertThat(validationError.get()).contains("PK가 user_id가 아닙니다");
+    }
+}


### PR DESCRIPTION
# 문제

운영 DB의 `users` 테이블이 현재 엔티티 스키마와 다르게 남아 있는 경우,
애플리케이션은 시작은 되더라도 회원가입/로그인 시점에 뒤늦게 `500 INTERNAL_SERVER_ERROR`로 터질 수 있었다.

실제 문제 상황은 다음과 같았다.

- 현재 엔티티는 `users.user_id`를 PK로 기대함
- 운영 DB에는 예전 구조인 `users.id` PK가 남아 있었음
- Hibernate가 `ddl-auto=update`로 이를 맞추려다 DDL 오류를 냄
- 그 결과 회원가입/로그인 요청에서 원인 파악이 어려운 서버 내부 오류가 발생함

즉, 스키마가 어긋난 상태를 서버 시작 시점에 바로 감지하지 못하고,
런타임 요청 처리 중 늦게 실패하는 구조가 문제였다.

# 수정 내용

`food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/auth/config/UsersTableSchemaValidator.java`

애플리케이션 시작 시 `users` 테이블 구조를 검사하는 검증기를 추가했다.

## 검증 내용

1. `users` 테이블이 존재하는지 확인
2. PK가 예전 `id`인지 확인
3. `user_id` 컬럼이 존재하는지 확인
4. 실제 PK가 `user_id`인지 확인

## 동작 방식

문제가 없는 경우:
- 아무 일 없이 애플리케이션 정상 시작

문제가 있는 경우:
- 앱 시작 단계에서 즉시 실패
- 왜 실패했는지 명확한 메시지 제공
- 예:
  - 레거시 `id` PK
