### PR TITLE
Bug/signup legacy users schema compat

### DIFF
--- a/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/auth/config/UsersTableSchemaValidator.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/auth/config/UsersTableSchemaValidator.java
@@ -52,19 +52,15 @@ public class UsersTableSchemaValidator implements ApplicationRunner {
         Set<String> normalizedColumns = normalize(columns);
         Set<String> normalizedPrimaryKeys = normalize(primaryKeys);
 
-        if (normalizedPrimaryKeys.contains("id") && !normalizedPrimaryKeys.contains("user_id")) {
+        if (!normalizedColumns.contains("id")) {
+            return Optional.of("users 테이블에 id 컬럼이 없습니다. 현재 엔티티 스키마와 DB 구조를 확인해주세요.");
+        }
+
+        if (!normalizedPrimaryKeys.contains("id")) {
             return Optional.of("""
-                    레거시 users 테이블 스키마가 감지되었습니다. 현재 애플리케이션은 users.user_id PK를 기대하지만, DB에는 기존 id PK가 남아 있습니다.
-                    기존 users 테이블을 정리한 뒤 서버를 다시 띄워 엔티티 기준으로 재생성해주세요.
+                    users 테이블의 PK가 id가 아닙니다. 현재 애플리케이션은 기존 users.id PK 스키마를 기대합니다.
+                    users 테이블을 현재 엔티티 기준으로 다시 확인해주세요.
                     """.strip());
-        }
-
-        if (!normalizedColumns.contains("user_id")) {
-            return Optional.of("users 테이블에 user_id 컬럼이 없습니다. 현재 엔티티 스키마와 DB 구조를 확인해주세요.");
-        }
-
-        if (!normalizedPrimaryKeys.contains("user_id")) {
-            return Optional.of("users 테이블의 PK가 user_id가 아닙니다. 현재 엔티티 스키마와 DB 구조를 확인해주세요.");
         }
 
         return Optional.empty();

--- a/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/auth/entity/UserAccount.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/auth/entity/UserAccount.java
@@ -13,7 +13,6 @@ public class UserAccount {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "user_id")
     private Long id;
 
     @Column(nullable = false, length = 50)

--- a/food-ai-platform-server/src/test/java/com/example/foodaiplatformserver/auth/config/UsersTableSchemaValidatorTest.java
+++ b/food-ai-platform-server/src/test/java/com/example/foodaiplatformserver/auth/config/UsersTableSchemaValidatorTest.java
@@ -10,38 +10,38 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class UsersTableSchemaValidatorTest {
 
-    @DisplayName("users 테이블이 예전 id PK를 쓰면 명확한 스키마 오류를 반환한다")
+    @DisplayName("users 테이블이 id PK를 쓰면 현재 인증 스키마로 판단한다")
     @Test
-    void returnsHelpfulMessageForLegacyPrimaryKey() {
+    void acceptsCurrentUsersSchema() {
         Optional<String> validationError = UsersTableSchemaValidator.validateUsersTableSchema(
                 Set.of("id", "username", "email", "password"),
                 Set.of("id")
         );
 
-        assertThat(validationError).isPresent();
-        assertThat(validationError.get()).contains("users.user_id PK");
+        assertThat(validationError).isEmpty();
     }
 
-    @DisplayName("users 테이블에 user_id PK가 있으면 정상 스키마로 판단한다")
+    @DisplayName("users 테이블에 id 컬럼이 없으면 오류를 반환한다")
     @Test
-    void acceptsExpectedUsersSchema() {
+    void returnsErrorWhenIdColumnMissing() {
         Optional<String> validationError = UsersTableSchemaValidator.validateUsersTableSchema(
                 Set.of("user_id", "username", "email", "password"),
                 Set.of("user_id")
         );
 
-        assertThat(validationError).isEmpty();
+        assertThat(validationError).isPresent();
+        assertThat(validationError.get()).contains("id 컬럼이 없습니다");
     }
 
-    @DisplayName("user_id 컬럼은 있지만 PK가 아니면 오류를 반환한다")
+    @DisplayName("id 컬럼은 있지만 PK가 아니면 오류를 반환한다")
     @Test
-    void returnsErrorWhenUserIdIsNotPrimaryKey() {
+    void returnsErrorWhenIdIsNotPrimaryKey() {
         Optional<String> validationError = UsersTableSchemaValidator.validateUsersTableSchema(
-                Set.of("user_id", "username", "email", "password"),
+                Set.of("id", "username", "email", "password"),
                 Set.of("email")
         );
 
         assertThat(validationError).isPresent();
-        assertThat(validationError.get()).contains("PK가 user_id가 아닙니다");
+        assertThat(validationError.get()).contains("PK가 id가 아닙니다");
     }
 }


### PR DESCRIPTION
# 문제

배포 서버에서 회원가입 API(`POST /api/v1/auth/signup`)가 계속 `500 INTERNAL_SERVER_ERROR`로 실패하고 있었다.

처음에는 `users.user_id`를 기준으로 엔티티를 맞췄지만,
실제 운영 DB는 기존 구조인 `users.id`를 PK로 사용하는 상태였고,
이 차이 때문에 회원가입/로그인 흐름이 깨질 가능성이 컸다.

즉, 현재 인증 엔티티가 기대하는 스키마와 운영 DB의 실제 `users` 테이블 구조가 서로 달라서
회원가입 시 저장 과정에서 오류가 발생하는 상황이었다.

# 수정 내용

## 1. `UserAccount` 엔티티를 기존 운영 스키마 기준으로 다시 맞춤

파일:
- `food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/auth/entity/UserAccount.java`

변경 내용:
- PK 컬럼을 `user_id`로 강제 매핑하던 설정 제거
- 기본 PK 컬럼 `id` 기준으로 동작하도록 복원

이렇게 해서 현재 운영 DB의 기존 `users.id` 구조와 인증 엔티티가 바로 맞도록 수정했다.

## 2. `UsersTableSchemaValidator` 기대값도 `id` 기준으로 수정

파일:
- `food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/auth/config/UsersTableSchemaValidator.java`

변경 내용:
- 기존에는 `users.user_id` PK를 기대하도록 되어 있었음
- 이제는 `users.id` 컬럼 존재 여부와 `id` PK 여부를 검사하도록 변경

즉, 스키마 검증 로직도 현재 운영 DB와 호환되는 방향으로 정리했다.

# 기대 효과

- 운영 DB가 기존 `users.id` PK 구조를 사용하고 있어도 회원가입/로그인이 정상 동작 가능
- 인증 엔티티와 실제 DB 스키마 불일치로 인한 `500 INTERNAL_SERVER_ERROR` 가능성 감소
- 시작 시점 스키마 검증도 현재 기대 구조와 일치하게 동작

# 테스트 수정

파일:
- `food-ai-platform-server/src/test/java/com/example/foodaiplatformserver/auth
