### PR TITLE
백엔드 API에 Swagger 문서화 적용

### DIFF
--- a/food-ai-platform-server/build.gradle
+++ b/food-ai-platform-server/build.gradle
@@ -20,6 +20,7 @@ repositories {
 
 dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.3'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'

--- a/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/auth/config/WebMvcAuthConfig.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/auth/config/WebMvcAuthConfig.java
@@ -29,7 +29,14 @@ public class WebMvcAuthConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(authInterceptor)
                 .addPathPatterns("/**")
-                .excludePathPatterns("/auth/signup", "/auth/login", "/error");
+                .excludePathPatterns(
+                        "/auth/signup",
+                        "/auth/login",
+                        "/error",
+                        "/v3/api-docs/**",
+                        "/swagger-ui/**",
+                        "/swagger-ui.html"
+                );
     }
 
     @Override

--- a/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/auth/controller/AuthController.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/auth/controller/AuthController.java
@@ -6,6 +6,10 @@ import com.example.foodaiplatformserver.auth.dto.AuthSignupRequest;
 import com.example.foodaiplatformserver.auth.dto.AuthSignupResponse;
 import com.example.foodaiplatformserver.auth.dto.AuthUserResponse;
 import com.example.foodaiplatformserver.auth.service.AuthService;
+import com.example.foodaiplatformserver.common.config.OpenApiConfig;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/auth")
+@Tag(name = "인증", description = "회원가입, 로그인, 내 정보 조회 API")
 public class AuthController {
 
     private final AuthService authService;
@@ -27,16 +32,20 @@ public class AuthController {
 
     @PostMapping("/signup")
     @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "회원가입", description = "이메일과 비밀번호로 회원가입합니다.")
     public AuthSignupResponse signup(@Valid @RequestBody AuthSignupRequest request) {
         return authService.signup(request);
     }
 
     @PostMapping("/login")
+    @Operation(summary = "로그인", description = "로그인 후 액세스 토큰과 사용자 정보를 반환합니다.")
     public AuthLoginResponse login(@Valid @RequestBody AuthLoginRequest request) {
         return authService.login(request);
     }
 
     @GetMapping("/me")
+    @Operation(summary = "내 정보 조회", description = "현재 인증된 사용자 정보를 조회합니다.")
+    @SecurityRequirement(name = OpenApiConfig.BEARER_SCHEME)
     public AuthUserResponse me() {
         return authService.me();
     }

--- a/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/common/config/OpenApiConfig.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/common/config/OpenApiConfig.java
@@ -1,0 +1,28 @@
+package com.example.foodaiplatformserver.common.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    public static final String BEARER_SCHEME = "bearerAuth";
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Food AI Platform API")
+                        .description("Food AI Platform 백엔드 API 문서")
+                        .version("v1"))
+                .components(new Components()
+                        .addSecuritySchemes(BEARER_SCHEME, new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")));
+    }
+}

--- a/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/fridgeitem/controller/FridgeItemController.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/fridgeitem/controller/FridgeItemController.java
@@ -6,7 +6,12 @@ import com.example.foodaiplatformserver.fridgeitem.dto.FridgeItemSummaryResponse
 import com.example.foodaiplatformserver.fridgeitem.entity.ItemStatus;
 import com.example.foodaiplatformserver.fridgeitem.entity.StorageLocation;
 import com.example.foodaiplatformserver.fridgeitem.service.FridgeItemService;
+import com.example.foodaiplatformserver.common.config.OpenApiConfig;
 import com.example.foodaiplatformserver.user.validation.EnumValue;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
@@ -26,6 +31,8 @@ import java.util.List;
 @Validated
 @RestController
 @RequestMapping("/fridge-items")
+@Tag(name = "냉장고 식재료", description = "냉장고 식재료 조회, 등록, 수정, 삭제 API")
+@SecurityRequirement(name = OpenApiConfig.BEARER_SCHEME)
 public class FridgeItemController {
 
     private final FridgeItemService fridgeItemService;
@@ -35,15 +42,20 @@ public class FridgeItemController {
     }
 
     @GetMapping("/summary")
+    @Operation(summary = "식재료 요약 조회", description = "냉장고 식재료 개수와 상태 요약을 조회합니다.")
     public FridgeItemSummaryResponse getSummary() {
         return fridgeItemService.getSummary();
     }
 
     @GetMapping
+    @Operation(summary = "식재료 목록 조회", description = "키워드, 보관 위치, 식품 상태로 식재료를 조회합니다.")
     public List<FridgeItemResponse> getItems(
+            @Parameter(description = "식재료 이름 검색 키워드")
             @RequestParam(required = false) String keyword,
+            @Parameter(description = "보관 위치 필터", example = "REFRIGERATED")
             @RequestParam(name = "storage_location", required = false)
             @EnumValue(enumClass = StorageLocation.class, message = "보관 위치 값이 올바르지 않습니다.") String storageLocation,
+            @Parameter(description = "식품 상태 필터", example = "SAFE")
             @RequestParam(required = false)
             @EnumValue(enumClass = ItemStatus.class, message = "식품 상태 값이 올바르지 않습니다.") String status
     ) {
@@ -52,11 +64,13 @@ public class FridgeItemController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "식재료 등록", description = "새 식재료를 냉장고에 등록합니다.")
     public FridgeItemResponse create(@Valid @RequestBody FridgeItemSaveRequest request) {
         return fridgeItemService.create(request);
     }
 
     @PutMapping("/{itemId}")
+    @Operation(summary = "식재료 수정", description = "기존 식재료 정보를 수정합니다.")
     public FridgeItemResponse update(@PathVariable Long itemId,
                                      @Valid @RequestBody FridgeItemSaveRequest request) {
         return fridgeItemService.update(itemId, request);
@@ -64,6 +78,7 @@ public class FridgeItemController {
 
     @DeleteMapping("/{itemId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(summary = "식재료 삭제", description = "식재료를 삭제합니다.")
     public void delete(@PathVariable Long itemId) {
         fridgeItemService.delete(itemId);
     }

--- a/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/recipe/controller/RecipeRecommendationController.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/recipe/controller/RecipeRecommendationController.java
@@ -2,12 +2,18 @@ package com.example.foodaiplatformserver.recipe.controller;
 
 import com.example.foodaiplatformserver.recipe.dto.RecipeRecommendationResponse;
 import com.example.foodaiplatformserver.recipe.service.RecipeRecommendationService;
+import com.example.foodaiplatformserver.common.config.OpenApiConfig;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/recipes")
+@Tag(name = "레시피 추천", description = "사용자 맞춤 레시피 추천 API")
+@SecurityRequirement(name = OpenApiConfig.BEARER_SCHEME)
 public class RecipeRecommendationController {
 
     private final RecipeRecommendationService recipeRecommendationService;
@@ -17,6 +23,7 @@ public class RecipeRecommendationController {
     }
 
     @GetMapping("/recommendations")
+    @Operation(summary = "추천 레시피 조회", description = "현재 사용자 기준 추천 레시피 목록을 조회합니다.")
     public RecipeRecommendationResponse getRecommendations() {
         return recipeRecommendationService.getRecommendations();
     }

--- a/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/user/controller/UserPreferenceController.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/user/controller/UserPreferenceController.java
@@ -3,6 +3,10 @@ package com.example.foodaiplatformserver.user.controller;
 import com.example.foodaiplatformserver.user.dto.UserPreferenceResponse;
 import com.example.foodaiplatformserver.user.dto.UserPreferenceUpsertRequest;
 import com.example.foodaiplatformserver.user.service.UserPreferenceService;
+import com.example.foodaiplatformserver.common.config.OpenApiConfig;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -12,6 +16,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/users/me/preferences")
+@Tag(name = "사용자 선호도", description = "현재 사용자 선호도 조회 및 저장 API")
+@SecurityRequirement(name = OpenApiConfig.BEARER_SCHEME)
 public class UserPreferenceController {
 
     private final UserPreferenceService userPreferenceService;
@@ -21,11 +27,13 @@ public class UserPreferenceController {
     }
 
     @PutMapping
+    @Operation(summary = "선호도 저장", description = "현재 사용자 선호도를 저장하거나 갱신합니다.")
     public UserPreferenceResponse upsert(@Valid @RequestBody UserPreferenceUpsertRequest request) {
         return userPreferenceService.upsert(request);
     }
 
     @GetMapping
+    @Operation(summary = "선호도 조회", description = "현재 사용자 선호도를 조회합니다.")
     public UserPreferenceResponse getCurrentUserPreference() {
         return userPreferenceService.getCurrentUserPreference();
     }

--- a/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/userrecipe/controller/UserRecipeController.java
+++ b/food-ai-platform-server/src/main/java/com/example/foodaiplatformserver/userrecipe/controller/UserRecipeController.java
@@ -3,6 +3,11 @@ package com.example.foodaiplatformserver.userrecipe.controller;
 import com.example.foodaiplatformserver.userrecipe.dto.UserRecipeCreateRequest;
 import com.example.foodaiplatformserver.userrecipe.dto.UserRecipeResponse;
 import com.example.foodaiplatformserver.userrecipe.service.UserRecipeService;
+import com.example.foodaiplatformserver.common.config.OpenApiConfig;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import org.springframework.http.HttpStatus;
@@ -20,6 +25,8 @@ import java.util.List;
 @Validated
 @RestController
 @RequestMapping("/user-recipes")
+@Tag(name = "사용자 레시피 히스토리", description = "사용자 레시피 저장 및 조회 API")
+@SecurityRequirement(name = OpenApiConfig.BEARER_SCHEME)
 public class UserRecipeController {
 
     private final UserRecipeService userRecipeService;
@@ -30,12 +37,15 @@ public class UserRecipeController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "레시피 히스토리 저장", description = "사용자가 선택한 레시피를 저장합니다.")
     public UserRecipeResponse create(@Valid @RequestBody UserRecipeCreateRequest request) {
         return userRecipeService.create(request);
     }
 
     @GetMapping
+    @Operation(summary = "내 레시피 히스토리 조회", description = "현재 사용자의 레시피 저장 이력을 조회합니다.")
     public List<UserRecipeResponse> getMyHistories(
+            @Parameter(description = "조회 개수 제한", example = "10")
             @RequestParam(name = "limit", required = false) @Min(value = 1, message = "limit는 1 이상이어야 합니다.") Integer limit
     ) {
         return userRecipeService.getMyHistories(limit);

--- a/food-ai-platform-server/src/main/resources/application.properties
+++ b/food-ai-platform-server/src/main/resources/application.properties
@@ -18,3 +18,4 @@ app.gemini.api-key=${APP_GEMINI_API_KEY:}
 app.gemini.model=${APP_GEMINI_MODEL:gemini-3.1-flash-lite}
 app.gemini.fallback-model=${APP_GEMINI_FALLBACK_MODEL:gemini-2.5-flash-lite}
 app.gemini.api-url=${APP_GEMINI_API_URL:https://generativelanguage.googleapis.com/v1beta}
+springdoc.swagger-ui.path=/swagger-ui.html


### PR DESCRIPTION
## Summary
- `springdoc-openapi`를 추가하고 OpenAPI/JWT Bearer 설정을 구성했습니다.
- Swagger UI와 OpenAPI 경로가 인증 인터셉터에 막히지 않도록 예외 처리했습니다.
- 주요 컨트롤러에 `@Tag`, `@Operation`, `@SecurityRequirement`를 붙여 API 문서를 정리했습니다.

## Testing
- `food-ai-platform-server`에서 `./gradlew test` 통과했습니다.